### PR TITLE
feat: Implement store profile creation and editing with geocoding sup…

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,26 @@ middleware.ts            — protects /dashboard/* routes
 | `npx prisma studio` | Open Prisma Studio (DB browser) |
 | `npx prisma migrate dev` | Run pending migrations |
 | `npm run test:auth` | HTTP integration tests for auth & session (needs running app) |
+| `npm run test:store-profile` | HTTP integration tests for store profile create/edit (needs running app + DB) |
+| `npm run test:geocode` | Geocoding branch tests (mocked; optional real Google API check) |
+
+### Running `test:geocode`
+
+`scripts/geocode-branch-tests.ts` exercises `lib/geocode-address.ts` in two ways:
+
+1. **Mocked (default, no network required)** — Always runs when you execute `npm run test:geocode`. It stubs `fetch` so you can assert both behaviors deterministically:
+   - Google returns `OK` → coordinates come from the API response.
+   - Google fails or the key is unset → deterministic Pittsburgh-area fallback is used.
+
+2. **Live integration (optional)** — Makes one real request to the Google Geocoding API to confirm your key, billing, and API restrictions work from your machine. Requires network access and `GOOGLE_MAPS_API_KEY` in `.env` (loaded via `dotenv`).
+
+   ```bash
+   GEOCODE_LIVE_TEST=1 npm run test:geocode
+   ```
+
+   If the live step passes, you should see a log line with `lat`/`lng` for a fixed Pittsburgh test address. If it fails, fix the key or Google Cloud console settings (Geocoding API enabled, key not overly restricted for server-side use) before relying on production geocoding.
+
+The live check is optional because CI and offline runs cannot depend on Google’s availability or quotas; the mocked tests are the stable regression suite.
 
 ### Running `test:auth`
 

--- a/app/(dashboard)/dashboard/profile/StoreProfileForm.tsx
+++ b/app/(dashboard)/dashboard/profile/StoreProfileForm.tsx
@@ -1,0 +1,207 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { useRouter } from "next/navigation";
+
+type StoreProfileInitial = {
+  id: string;
+  name: string;
+  address: string;
+  categories: string[];
+  open: string;
+  close: string;
+  isPublished: boolean;
+} | null;
+
+type FieldErrors = Record<string, string>;
+
+const CATEGORY_OPTIONS = [
+  { key: "asian", label: "Asian groceries" },
+  { key: "halal", label: "Halal" },
+  { key: "organic", label: "Organic" },
+  { key: "produce", label: "Produce" },
+  { key: "ebt", label: "EBT Accepted" },
+];
+
+export default function StoreProfileForm({ initial }: { initial: StoreProfileInitial }) {
+  const router = useRouter();
+  const [name, setName] = useState(initial?.name ?? "");
+  const [address, setAddress] = useState(initial?.address ?? "");
+  const [open, setOpen] = useState(initial?.open ?? "08:00");
+  const [close, setClose] = useState(initial?.close ?? "20:00");
+  const [categories, setCategories] = useState<string[]>(initial?.categories ?? []);
+  const [fieldErrors, setFieldErrors] = useState<FieldErrors>({});
+  const [formError, setFormError] = useState<string>("");
+  const [savedMessage, setSavedMessage] = useState<string>("");
+  const [loading, setLoading] = useState(false);
+
+  const isExisting = Boolean(initial?.id);
+  const actionLabel = useMemo(
+    () => (isExisting ? "Update store profile" : "Publish store profile"),
+    [isExisting]
+  );
+
+  function toggleCategory(category: string) {
+    setCategories((prev) =>
+      prev.includes(category) ? prev.filter((c) => c !== category) : [...prev, category]
+    );
+  }
+
+  async function submit(publish: boolean) {
+    setLoading(true);
+    setFormError("");
+    setSavedMessage("");
+    setFieldErrors({});
+
+    const payload = {
+      name,
+      address,
+      hours: { open, close },
+      categories,
+      ...(isExisting ? { isPublished: publish } : {}),
+    };
+
+    const endpoint = isExisting ? `/api/stores/${initial!.id}` : "/api/stores";
+    const method = isExisting ? "PATCH" : "POST";
+
+    try {
+      const res = await fetch(endpoint, {
+        method,
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload),
+      });
+
+      const json = (await res.json().catch(() => null)) as
+        | {
+            error?: string;
+            fieldErrors?: FieldErrors;
+            store?: { id: string };
+          }
+        | null;
+
+      if (!res.ok) {
+        setFieldErrors(json?.fieldErrors ?? {});
+        setFormError(json?.error ?? "Failed to save profile.");
+        return;
+      }
+
+      setSavedMessage(publish ? "Store profile published." : "Store profile saved as draft.");
+      router.refresh();
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <>
+      <div className="bg-white rounded-2xl border border-gray-200 p-6 mb-4 shadow-sm">
+        <h2 className="text-[17px] font-semibold text-gray-800 mb-4">Store details</h2>
+
+        <div className="mb-4">
+          <label className="block text-[13px] font-medium text-gray-600 mb-1.5">Store name *</label>
+          <input
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            className="w-full px-3.5 py-2.5 rounded-md border-[1.5px] border-gray-200 text-[15px] text-gray-800 bg-white outline-none focus:border-green-400 transition-colors"
+            placeholder="e.g. Sultan Bey International"
+          />
+          {fieldErrors.name && <p className="text-[12px] text-red-700 mt-1.5">{fieldErrors.name}</p>}
+        </div>
+
+        <div className="mb-4">
+          <label className="block text-[13px] font-medium text-gray-600 mb-1.5">Address *</label>
+          <input
+            value={address}
+            onChange={(e) => setAddress(e.target.value)}
+            className="w-full px-3.5 py-2.5 rounded-md border-[1.5px] border-gray-200 text-[15px] text-gray-800 bg-white outline-none focus:border-green-400 transition-colors"
+            placeholder="142 Beaver St, Sewickley, PA 15143"
+          />
+          {fieldErrors.address && (
+            <p className="text-[12px] text-red-700 mt-1.5">{fieldErrors.address}</p>
+          )}
+        </div>
+
+        <div className="grid grid-cols-2 gap-3 mb-4">
+          <div>
+            <label className="block text-[13px] font-medium text-gray-600 mb-1.5">Opening time *</label>
+            <input
+              type="time"
+              value={open}
+              onChange={(e) => setOpen(e.target.value)}
+              className="w-full px-3.5 py-2.5 rounded-md border-[1.5px] border-gray-200 text-[15px] text-gray-800 bg-white outline-none focus:border-green-400 transition-colors"
+            />
+          </div>
+          <div>
+            <label className="block text-[13px] font-medium text-gray-600 mb-1.5">Closing time *</label>
+            <input
+              type="time"
+              value={close}
+              onChange={(e) => setClose(e.target.value)}
+              className="w-full px-3.5 py-2.5 rounded-md border-[1.5px] border-gray-200 text-[15px] text-gray-800 bg-white outline-none focus:border-green-400 transition-colors"
+            />
+          </div>
+        </div>
+        {fieldErrors.hours && <p className="text-[12px] text-red-700 mt-1.5">{fieldErrors.hours}</p>}
+      </div>
+
+      <div className="bg-white rounded-2xl border border-gray-200 p-6 mb-6 shadow-sm">
+        <h2 className="text-[17px] font-semibold text-gray-800 mb-2">Specialty categories</h2>
+        <p className="text-[14px] text-gray-400 mb-3.5">Select all that apply - shoppers filter by these</p>
+        <div className="flex flex-wrap gap-2">
+          {CATEGORY_OPTIONS.map((option) => {
+            const active = categories.includes(option.key);
+            return (
+              <button
+                type="button"
+                key={option.key}
+                onClick={() => toggleCategory(option.key)}
+                className={`px-3.5 py-1.5 rounded-full text-[13px] border-[1.5px] transition-colors ${
+                  active
+                    ? "text-green-700 border-green-500 bg-green-50"
+                    : "text-gray-600 border-gray-200 bg-white hover:border-green-400 hover:text-green-600"
+                }`}
+              >
+                {option.label}
+              </button>
+            );
+          })}
+        </div>
+        {fieldErrors.categories && (
+          <p className="text-[12px] text-red-700 mt-1.5">{fieldErrors.categories}</p>
+        )}
+      </div>
+
+      {formError && (
+        <div className="mb-4 rounded-lg border border-red-200 bg-red-50 px-3 py-2 text-[13px] text-red-800">
+          {formError}
+        </div>
+      )}
+      {savedMessage && (
+        <div className="mb-4 rounded-lg border border-green-200 bg-green-50 px-3 py-2 text-[13px] text-green-800">
+          {savedMessage}
+        </div>
+      )}
+
+      <div className="flex gap-2.5">
+        <button
+          type="button"
+          disabled={loading}
+          onClick={() => submit(true)}
+          className="px-5 py-2.5 rounded-md text-sm font-medium text-white bg-green-600 hover:bg-green-800 disabled:opacity-50 transition-colors"
+        >
+          {loading ? "Saving..." : `${actionLabel} ->`}
+        </button>
+        {isExisting && (
+          <button
+            type="button"
+            disabled={loading}
+            onClick={() => submit(false)}
+            className="px-5 py-2.5 rounded-md text-sm font-medium text-gray-600 border border-gray-200 hover:bg-gray-100 disabled:opacity-50 transition-colors"
+          >
+            Save as draft
+          </button>
+        )}
+      </div>
+    </>
+  );
+}

--- a/app/(dashboard)/dashboard/profile/page.tsx
+++ b/app/(dashboard)/dashboard/profile/page.tsx
@@ -1,8 +1,41 @@
-// TODO: Story 7 (Create a Store Profile)
-
 import Link from "next/link";
+import { auth } from "@/auth";
+import { prisma } from "@/lib/prisma";
+import StoreProfileForm from "./StoreProfileForm";
 
-export default function StoreProfileEditPage() {
+export default async function StoreProfileEditPage() {
+  const session = await auth();
+  const ownerId = session?.user?.id ?? "";
+  const existingStore = ownerId
+    ? await prisma.store.findUnique({
+        where: { ownerId },
+        select: {
+          id: true,
+          name: true,
+          address: true,
+          categories: true,
+          hours: true,
+          isPublished: true,
+        },
+      })
+    : null;
+
+  const rawHours =
+    existingStore?.hours && typeof existingStore.hours === "object"
+      ? (existingStore.hours as { open?: unknown; close?: unknown })
+      : {};
+  const initial = existingStore
+    ? {
+        id: existingStore.id,
+        name: existingStore.name,
+        address: existingStore.address,
+        categories: existingStore.categories,
+        open: typeof rawHours.open === "string" ? rawHours.open : "08:00",
+        close: typeof rawHours.close === "string" ? rawHours.close : "20:00",
+        isPublished: existingStore.isPublished,
+      }
+    : null;
+
   return (
     <div className="max-w-[600px]">
       <div className="mb-7">
@@ -15,95 +48,11 @@ export default function StoreProfileEditPage() {
         <p className="text-[15px] text-gray-600 mt-1.5">
           Shoppers see this on the directory and your store page.
         </p>
-        <Link
-          href="/"
-          className="inline-flex mt-3 text-[13px] text-green-600 font-medium hover:text-green-800"
-        >
+        <Link href="/" className="inline-flex mt-3 text-[13px] text-green-600 font-medium hover:text-green-800">
           ← Back to site
         </Link>
       </div>
-
-      {/* Store details */}
-      <div className="bg-white rounded-2xl border border-gray-200 p-6 mb-4 shadow-sm">
-        <h2 className="text-[17px] font-semibold text-gray-800 mb-4">
-          Store details
-        </h2>
-
-        <div className="mb-4">
-          <label className="block text-[13px] font-medium text-gray-600 mb-1.5">
-            Store name *
-          </label>
-          <input
-            className="w-full px-3.5 py-2.5 rounded-md border-[1.5px] border-gray-200 text-[15px] text-gray-800 bg-white outline-none focus:border-green-400 transition-colors"
-            placeholder="e.g. Sultan Bey International"
-          />
-        </div>
-
-        <div className="mb-4">
-          <label className="block text-[13px] font-medium text-gray-600 mb-1.5">
-            Address *
-          </label>
-          <input
-            className="w-full px-3.5 py-2.5 rounded-md border-[1.5px] border-gray-200 text-[15px] text-gray-800 bg-white outline-none focus:border-green-400 transition-colors"
-            placeholder="142 Beaver St, Sewickley, PA 15143"
-          />
-        </div>
-
-        <div className="grid grid-cols-2 gap-3 mb-4">
-          <div>
-            <label className="block text-[13px] font-medium text-gray-600 mb-1.5">
-              Opening time *
-            </label>
-            <input
-              type="time"
-              defaultValue="08:00"
-              className="w-full px-3.5 py-2.5 rounded-md border-[1.5px] border-gray-200 text-[15px] text-gray-800 bg-white outline-none focus:border-green-400 transition-colors"
-            />
-          </div>
-          <div>
-            <label className="block text-[13px] font-medium text-gray-600 mb-1.5">
-              Closing time *
-            </label>
-            <input
-              type="time"
-              defaultValue="20:00"
-              className="w-full px-3.5 py-2.5 rounded-md border-[1.5px] border-gray-200 text-[15px] text-gray-800 bg-white outline-none focus:border-green-400 transition-colors"
-            />
-          </div>
-        </div>
-      </div>
-
-      {/* Categories */}
-      <div className="bg-white rounded-2xl border border-gray-200 p-6 mb-6 shadow-sm">
-        <h2 className="text-[17px] font-semibold text-gray-800 mb-2">
-          Specialty categories
-        </h2>
-        <p className="text-[14px] text-gray-400 mb-3.5">
-          Select all that apply — shoppers filter by these
-        </p>
-        <div className="flex flex-wrap gap-2">
-          {["🥢 Asian groceries", "☪ Halal", "🌿 Organic", "🥦 Produce", "💳 EBT Accepted"].map(
-            (label) => (
-              <button
-                key={label}
-                className="px-3.5 py-1.5 rounded-full text-[13px] text-gray-600 border-[1.5px] border-gray-200 bg-white hover:border-green-400 hover:text-green-600 transition-colors"
-              >
-                {label}
-              </button>
-            )
-          )}
-        </div>
-      </div>
-
-      {/* Actions */}
-      <div className="flex gap-2.5">
-        <button className="px-5 py-2.5 rounded-md text-sm font-medium text-white bg-green-600 hover:bg-green-800 transition-colors">
-          Publish store profile &rarr;
-        </button>
-        <button className="px-5 py-2.5 rounded-md text-sm font-medium text-gray-600 border border-gray-200 hover:bg-gray-100 transition-colors">
-          Save as draft
-        </button>
-      </div>
+      <StoreProfileForm initial={initial} />
     </div>
   );
 }

--- a/app/api/stores/[id]/route.ts
+++ b/app/api/stores/[id]/route.ts
@@ -1,5 +1,6 @@
 import type { Prisma } from "@/app/generated/prisma/client";
 import { NextRequest, NextResponse } from "next/server";
+import { geocodeAddress } from "@/lib/geocode-address";
 import { prisma } from "@/lib/prisma";
 import { requireStoreOwnerForStore } from "@/lib/require-store-owner";
 
@@ -60,14 +61,46 @@ export async function PATCH(
   } = body;
 
   const patch: Prisma.StoreUpdateInput = {};
-  if (typeof data.name === "string") patch.name = data.name;
-  if (typeof data.address === "string") patch.address = data.address;
+  if (typeof data.name === "string") patch.name = data.name.trim();
+  if (typeof data.address === "string") patch.address = data.address.trim();
   if (data.hours !== undefined) patch.hours = data.hours as Prisma.InputJsonValue;
-  if (Array.isArray(data.categories)) patch.categories = data.categories;
+  if (Array.isArray(data.categories)) {
+    patch.categories = data.categories
+      .filter((c): c is string => typeof c === "string")
+      .map((c) => c.trim().toLowerCase())
+      .filter(Boolean);
+  }
   if (typeof data.is_published === "boolean")
     patch.isPublished = data.is_published;
   if (typeof data.isPublished === "boolean")
     patch.isPublished = data.isPublished;
+
+  const nextPublished = (patch.isPublished as boolean | undefined) ?? gate.store.isPublished;
+  const togglingToPublished = patch.isPublished === true && !gate.store.isPublished;
+  const nextAddress = (patch.address as string | undefined) ?? gate.store.address;
+  const nextCategories = (patch.categories as string[] | undefined) ?? gate.store.categories;
+  const nextHours =
+    (patch.hours as Prisma.InputJsonValue | undefined) ?? (gate.store.hours as Prisma.JsonValue);
+
+  if (
+    togglingToPublished &&
+    (!nextAddress || !nextHours || !Array.isArray(nextCategories) || nextCategories.length === 0)
+  ) {
+    return NextResponse.json(
+      {
+        error:
+          "Published profiles require address, hours, and at least one specialty category.",
+      },
+      { status: 400 }
+    );
+  }
+
+  const shouldGeocode = Boolean(nextPublished && patch.address);
+  if (shouldGeocode) {
+    const coords = await geocodeAddress(nextAddress);
+    patch.lat = coords.lat;
+    patch.lng = coords.lng;
+  }
 
   if (Object.keys(patch).length === 0) {
     return NextResponse.json(

--- a/app/api/stores/[id]/route.ts
+++ b/app/api/stores/[id]/route.ts
@@ -3,6 +3,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { geocodeAddress } from "@/lib/geocode-address";
 import { prisma } from "@/lib/prisma";
 import { requireStoreOwnerForStore } from "@/lib/require-store-owner";
+import { validateStoreProfilePatch } from "@/lib/store-profile";
 
 // Story 3: GET /api/stores/:id — Get single store profile
 // Story 12: No auth required
@@ -51,29 +52,21 @@ export async function PATCH(
     return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
   }
 
-  const data: {
-    name?: string;
-    address?: string;
-    hours?: unknown;
-    categories?: string[];
-    is_published?: boolean;
-    isPublished?: boolean;
-  } = body;
+  const validated = validateStoreProfilePatch(body as Record<string, unknown>);
+  if (!validated.ok) {
+    return NextResponse.json(
+      { error: "Validation failed", fieldErrors: validated.errors },
+      { status: 400 }
+    );
+  }
 
   const patch: Prisma.StoreUpdateInput = {};
-  if (typeof data.name === "string") patch.name = data.name.trim();
-  if (typeof data.address === "string") patch.address = data.address.trim();
-  if (data.hours !== undefined) patch.hours = data.hours as Prisma.InputJsonValue;
-  if (Array.isArray(data.categories)) {
-    patch.categories = data.categories
-      .filter((c): c is string => typeof c === "string")
-      .map((c) => c.trim().toLowerCase())
-      .filter(Boolean);
-  }
-  if (typeof data.is_published === "boolean")
-    patch.isPublished = data.is_published;
-  if (typeof data.isPublished === "boolean")
-    patch.isPublished = data.isPublished;
+  const v = validated.data;
+  if (v.name !== undefined) patch.name = v.name;
+  if (v.address !== undefined) patch.address = v.address;
+  if (v.hours !== undefined) patch.hours = v.hours as Prisma.InputJsonValue;
+  if (v.categories !== undefined) patch.categories = v.categories;
+  if (v.isPublished !== undefined) patch.isPublished = v.isPublished;
 
   const nextPublished = (patch.isPublished as boolean | undefined) ?? gate.store.isPublished;
   const togglingToPublished = patch.isPublished === true && !gate.store.isPublished;

--- a/app/api/stores/route.ts
+++ b/app/api/stores/route.ts
@@ -1,5 +1,8 @@
 import { NextRequest, NextResponse } from "next/server";
+import { auth } from "@/auth";
+import { geocodeAddress } from "@/lib/geocode-address";
 import { prisma } from "@/lib/prisma";
+import { validateStoreProfileCreate } from "@/lib/store-profile";
 
 type StoreResult = {
   id: string;
@@ -98,6 +101,46 @@ export async function GET(req: NextRequest) {
 }
 
 // Story 7: POST /api/stores — Create store profile (triggers geocoding)
-export async function POST() {
-  return NextResponse.json({ message: "TODO: Create store" }, { status: 501 });
+export async function POST(req: NextRequest) {
+  const session = await auth();
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const body = await req.json().catch(() => null);
+  const validated = validateStoreProfileCreate(body);
+  if (!validated.ok) {
+    return NextResponse.json(
+      { error: "Validation failed", fieldErrors: validated.errors },
+      { status: 400 }
+    );
+  }
+
+  const existing = await prisma.store.findUnique({
+    where: { ownerId: session.user.id },
+    select: { id: true },
+  });
+  if (existing) {
+    return NextResponse.json(
+      { error: "Store already exists for this owner." },
+      { status: 409 }
+    );
+  }
+
+  const coords = await geocodeAddress(validated.data.address);
+
+  const store = await prisma.store.create({
+    data: {
+      ownerId: session.user.id,
+      name: validated.data.name,
+      address: validated.data.address,
+      hours: validated.data.hours,
+      categories: validated.data.categories,
+      isPublished: true,
+      lat: coords.lat,
+      lng: coords.lng,
+    },
+  });
+
+  return NextResponse.json({ store }, { status: 201 });
 }

--- a/lib/geocode-address.ts
+++ b/lib/geocode-address.ts
@@ -1,0 +1,81 @@
+import { PITTSBURGH_NEIGHBORHOODS } from "@/lib/neighborhoods";
+
+type Coordinates = { lat: number; lng: number };
+
+function deterministicGeocode(address: string): Coordinates {
+  const normalized = address.trim().toLowerCase();
+  for (const [name, coords] of Object.entries(PITTSBURGH_NEIGHBORHOODS)) {
+    if (normalized.includes(name.toLowerCase())) {
+      return coords;
+    }
+  }
+
+  let hash = 0;
+  for (let i = 0; i < normalized.length; i += 1) {
+    hash = (hash * 31 + normalized.charCodeAt(i)) >>> 0;
+  }
+
+  const latOffset = ((hash % 7000) - 3500) / 100000;
+  const lngOffset = (((hash >> 13) % 7000) - 3500) / 100000;
+
+  return {
+    lat: 40.4406 + latOffset,
+    lng: -79.9959 + lngOffset,
+  };
+}
+
+/**
+ * Resolves an address to lat/lng. Tries Google Geocoding when `GOOGLE_MAPS_API_KEY` is set;
+ * on any failure (missing key, HTTP error, ZERO_RESULTS, quota, network), falls back to a
+ * deterministic Pittsburgh-area approximation so owners can still publish. Logs when fallback
+ * is used so bad addresses or API issues are visible in server logs.
+ */
+export async function geocodeAddress(address: string): Promise<Coordinates> {
+  const apiKey = process.env.GOOGLE_MAPS_API_KEY;
+  if (!apiKey) {
+    console.warn("geocodeAddress: no GOOGLE_MAPS_API_KEY; using deterministic fallback");
+    return deterministicGeocode(address);
+  }
+
+  const endpoint = new URL("https://maps.googleapis.com/maps/api/geocode/json");
+  endpoint.searchParams.set("address", address);
+  endpoint.searchParams.set("key", apiKey);
+
+  try {
+    const res = await fetch(endpoint.toString(), {
+      method: "GET",
+      headers: { Accept: "application/json" },
+      cache: "no-store",
+    });
+    if (!res.ok) {
+      console.warn(
+        `geocodeAddress: Google HTTP ${res.status}; using deterministic fallback`
+      );
+      return deterministicGeocode(address);
+    }
+
+    const data = (await res.json()) as {
+      status?: string;
+      results?: Array<{
+        geometry?: { location?: { lat?: number; lng?: number } };
+      }>;
+    };
+
+    const location = data.results?.[0]?.geometry?.location;
+    if (
+      data.status === "OK" &&
+      typeof location?.lat === "number" &&
+      typeof location?.lng === "number"
+    ) {
+      return { lat: location.lat, lng: location.lng };
+    }
+
+    console.warn(
+      `geocodeAddress: Google status=${data.status ?? "unknown"}; using deterministic fallback`
+    );
+  } catch (error) {
+    console.error("geocodeAddress failed; using deterministic fallback", error);
+  }
+
+  return deterministicGeocode(address);
+}

--- a/lib/store-profile.ts
+++ b/lib/store-profile.ts
@@ -1,0 +1,76 @@
+export type StoreProfileInput = {
+  name: string;
+  address: string;
+  hours: { open: string; close: string };
+  categories: string[];
+  isPublished: boolean;
+};
+
+export type ValidationResult<T> =
+  | { ok: true; data: T }
+  | { ok: false; errors: Record<string, string> };
+
+const CATEGORY_ALLOWLIST = new Set(["asian", "halal", "organic", "produce", "ebt"]);
+
+function asTrimmedString(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+function parseCategories(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  return value
+    .filter((v): v is string => typeof v === "string")
+    .map((v) => v.trim().toLowerCase())
+    .filter(Boolean)
+    .filter((v, idx, arr) => arr.indexOf(v) === idx);
+}
+
+function parseHours(value: unknown): { open: string; close: string } | null {
+  if (!value || typeof value !== "object") return null;
+  const raw = value as { open?: unknown; close?: unknown };
+  const open = asTrimmedString(raw.open);
+  const close = asTrimmedString(raw.close);
+  if (!open || !close) return null;
+
+  const isValidTime = (t: string) => /^([01]\d|2[0-3]):([0-5]\d)$/.test(t);
+  if (!isValidTime(open) || !isValidTime(close)) return null;
+
+  return { open, close };
+}
+
+export function validateStoreProfileCreate(body: unknown): ValidationResult<StoreProfileInput> {
+  if (!body || typeof body !== "object") {
+    return { ok: false, errors: { form: "Invalid JSON body." } };
+  }
+  const input = body as Record<string, unknown>;
+  const name = asTrimmedString(input.name);
+  const address = asTrimmedString(input.address);
+  const hours = parseHours(input.hours);
+  const categories = parseCategories(input.categories);
+
+  const errors: Record<string, string> = {};
+  if (!name) errors.name = "Store name is required.";
+  if (!address) errors.address = "Address is required.";
+  if (!hours) errors.hours = "Hours are required (open and close, HH:mm).";
+  if (categories.length === 0) errors.categories = "Select at least one specialty category.";
+  if (categories.some((c) => !CATEGORY_ALLOWLIST.has(c))) {
+    errors.categories = "One or more categories are invalid.";
+  }
+
+  if (Object.keys(errors).length > 0) {
+    return { ok: false, errors };
+  }
+
+  return {
+    ok: true,
+    data: {
+      name: name!,
+      address: address!,
+      hours: hours!,
+      categories,
+      isPublished: true,
+    },
+  };
+}

--- a/lib/store-profile.ts
+++ b/lib/store-profile.ts
@@ -18,7 +18,7 @@ function asTrimmedString(value: unknown): string | null {
   return trimmed.length > 0 ? trimmed : null;
 }
 
-function parseCategories(value: unknown): string[] {
+export function parseCategories(value: unknown): string[] {
   if (!Array.isArray(value)) return [];
   return value
     .filter((v): v is string => typeof v === "string")
@@ -27,7 +27,7 @@ function parseCategories(value: unknown): string[] {
     .filter((v, idx, arr) => arr.indexOf(v) === idx);
 }
 
-function parseHours(value: unknown): { open: string; close: string } | null {
+export function parseHours(value: unknown): { open: string; close: string } | null {
   if (!value || typeof value !== "object") return null;
   const raw = value as { open?: unknown; close?: unknown };
   const open = asTrimmedString(raw.open);
@@ -73,4 +73,70 @@ export function validateStoreProfileCreate(body: unknown): ValidationResult<Stor
       isPublished: true,
     },
   };
+}
+
+/** Fields allowed on PATCH; only keys present on the request body are validated and returned. */
+export type StoreProfileValidatedPatch = {
+  name?: string;
+  address?: string;
+  hours?: { open: string; close: string };
+  categories?: string[];
+  isPublished?: boolean;
+};
+
+export function validateStoreProfilePatch(
+  body: Record<string, unknown>
+): ValidationResult<StoreProfileValidatedPatch> {
+  const errors: Record<string, string> = {};
+
+  if ("name" in body) {
+    const name = asTrimmedString(body.name);
+    if (!name) errors.name = "Store name cannot be empty.";
+  }
+  if ("address" in body) {
+    const address = asTrimmedString(body.address);
+    if (!address) errors.address = "Address cannot be empty.";
+  }
+  if ("hours" in body) {
+    const hours = parseHours(body.hours);
+    if (!hours) {
+      errors.hours =
+        "Hours must include valid open and close times in HH:mm (24-hour).";
+    }
+  }
+  if ("categories" in body) {
+    if (!Array.isArray(body.categories)) {
+      errors.categories = "Categories must be an array.";
+    } else {
+      const categories = parseCategories(body.categories);
+      if (categories.length === 0) {
+        errors.categories = "Select at least one specialty category.";
+      } else if (categories.some((c) => !CATEGORY_ALLOWLIST.has(c))) {
+        errors.categories = "One or more categories are invalid.";
+      }
+    }
+  }
+  if ("is_published" in body && typeof body.is_published !== "boolean") {
+    errors.is_published = "is_published must be a boolean.";
+  }
+  if ("isPublished" in body && typeof body.isPublished !== "boolean") {
+    errors.isPublished = "isPublished must be a boolean.";
+  }
+
+  if (Object.keys(errors).length > 0) {
+    return { ok: false, errors };
+  }
+
+  const data: StoreProfileValidatedPatch = {};
+  if ("name" in body) data.name = asTrimmedString(body.name)!;
+  if ("address" in body) data.address = asTrimmedString(body.address)!;
+  if ("hours" in body) data.hours = parseHours(body.hours)!;
+  if ("categories" in body) data.categories = parseCategories(body.categories);
+  if (typeof body.isPublished === "boolean") {
+    data.isPublished = body.isPublished;
+  } else if (typeof body.is_published === "boolean") {
+    data.isPublished = body.is_published;
+  }
+
+  return { ok: true, data };
 }

--- a/package.json
+++ b/package.json
@@ -9,7 +9,9 @@
     "lint": "eslint",
     "db:seed": "tsx prisma/seed.ts",
     "db:reset": "prisma migrate reset --force && npm run db:seed",
-    "test:auth": "tsx scripts/auth-machine-tests.ts"
+    "test:auth": "tsx scripts/auth-machine-tests.ts",
+    "test:store-profile": "tsx scripts/store-profile-machine-tests.ts",
+    "test:geocode": "tsx scripts/geocode-branch-tests.ts"
   },
   "dependencies": {
     "@prisma/adapter-pg": "^7.5.0",

--- a/scripts/geocode-branch-tests.ts
+++ b/scripts/geocode-branch-tests.ts
@@ -1,0 +1,155 @@
+/**
+ * Verifies geocodeAddress behavior:
+ * 1) Google returns OK → use API lat/lng
+ * 2) Google fails or key missing → deterministic Pittsburgh fallback
+ *
+ * Mocked tests (always run):
+ *   npm run test:geocode
+ *
+ * Optional live call against real Geocoding API (uses .env GOOGLE_MAPS_API_KEY):
+ *   GEOCODE_LIVE_TEST=1 npm run test:geocode
+ */
+
+import "dotenv/config";
+import { strict as assert } from "node:assert";
+
+const SEWICKLEY_SAMPLE = "142 Beaver St, Sewickley, PA 15143";
+const SEWICKLEY_FALLBACK = { lat: 40.5338, lng: -80.1854 };
+
+async function withGeocodeEnv(
+  env: { GOOGLE_MAPS_API_KEY?: string | undefined },
+  fn: () => Promise<void>
+) {
+  const prev = process.env.GOOGLE_MAPS_API_KEY;
+  try {
+    if (env.GOOGLE_MAPS_API_KEY === undefined) {
+      delete process.env.GOOGLE_MAPS_API_KEY;
+    } else {
+      process.env.GOOGLE_MAPS_API_KEY = env.GOOGLE_MAPS_API_KEY;
+    }
+    await fn();
+  } finally {
+    if (prev === undefined) {
+      delete process.env.GOOGLE_MAPS_API_KEY;
+    } else {
+      process.env.GOOGLE_MAPS_API_KEY = prev;
+    }
+  }
+}
+
+function withMockFetch(mock: typeof fetch, fn: () => Promise<void>) {
+  const real = globalThis.fetch;
+  globalThis.fetch = mock;
+  return fn().finally(() => {
+    globalThis.fetch = real;
+  });
+}
+
+async function runMockedTests() {
+  const { geocodeAddress } = await import("../lib/geocode-address");
+
+  // Branch A: valid Google JSON response → use API coordinates (not fallback)
+  await withGeocodeEnv({ GOOGLE_MAPS_API_KEY: "test-key-mocked" }, async () => {
+    await withMockFetch(
+      async () =>
+        new Response(
+          JSON.stringify({
+            status: "OK",
+            results: [
+              {
+                geometry: { location: { lat: 40.123456, lng: -79.987654 } },
+              },
+            ],
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } }
+        ),
+      async () => {
+        const c = await geocodeAddress("any query string");
+        assert.equal(c.lat, 40.123456);
+        assert.equal(c.lng, -79.987654);
+      }
+    );
+  });
+
+  // Branch B: API key present but Google returns ZERO_RESULTS → fallback
+  await withGeocodeEnv({ GOOGLE_MAPS_API_KEY: "test-key-mocked" }, async () => {
+    await withMockFetch(
+      async () =>
+        new Response(
+          JSON.stringify({ status: "ZERO_RESULTS", results: [] }),
+          { status: 200, headers: { "Content-Type": "application/json" } }
+        ),
+      async () => {
+        const c = await geocodeAddress(SEWICKLEY_SAMPLE);
+        assert.equal(c.lat, SEWICKLEY_FALLBACK.lat);
+        assert.equal(c.lng, SEWICKLEY_FALLBACK.lng);
+      }
+    );
+  });
+
+  // Branch C: no API key → fallback, fetch must not be used
+  await withGeocodeEnv({ GOOGLE_MAPS_API_KEY: undefined }, async () => {
+    await withMockFetch(
+      async () => {
+        throw new Error("fetch should not run when GOOGLE_MAPS_API_KEY is unset");
+      },
+      async () => {
+        const c = await geocodeAddress(SEWICKLEY_SAMPLE);
+        assert.equal(c.lat, SEWICKLEY_FALLBACK.lat);
+        assert.equal(c.lng, SEWICKLEY_FALLBACK.lng);
+      }
+    );
+  });
+
+  // Branch D: HTTP error from Google → fallback
+  await withGeocodeEnv({ GOOGLE_MAPS_API_KEY: "test-key-mocked" }, async () => {
+    await withMockFetch(
+      async () => new Response("Forbidden", { status: 403 }),
+      async () => {
+        const c = await geocodeAddress(SEWICKLEY_SAMPLE);
+        assert.equal(c.lat, SEWICKLEY_FALLBACK.lat);
+        assert.equal(c.lng, SEWICKLEY_FALLBACK.lng);
+      }
+    );
+  });
+}
+
+async function runLiveTestIfRequested() {
+  if (process.env.GEOCODE_LIVE_TEST !== "1") {
+    return;
+  }
+  const key = process.env.GOOGLE_MAPS_API_KEY;
+  assert.ok(key && key.length > 0, "GEOCODE_LIVE_TEST=1 requires GOOGLE_MAPS_API_KEY");
+
+  const { geocodeAddress } = await import("../lib/geocode-address");
+  const address = "6000 Forbes Ave, Pittsburgh, PA 15217";
+  const c = await geocodeAddress(address);
+
+  assert.ok(
+    c.lat > 40.3 && c.lat < 40.55 && c.lng < -79.7 && c.lng > -80.2,
+    `live geocode for "${address}" should land near Pittsburgh, got lat=${c.lat} lng=${c.lng}`
+  );
+
+  console.log(`Live Geocoding API OK: "${address}" -> lat=${c.lat}, lng=${c.lng}`);
+}
+
+async function main() {
+  console.log("Running mocked geocode branch tests…");
+  await runMockedTests();
+  console.log("Mocked geocode branch tests passed.");
+
+  if (process.env.GEOCODE_LIVE_TEST === "1") {
+    console.log("Running live Geocoding API check (GEOCODE_LIVE_TEST=1)…");
+    await runLiveTestIfRequested();
+    console.log("Live geocode check passed.");
+  } else {
+    console.log(
+      "Skip live API test (set GEOCODE_LIVE_TEST=1 to hit real Geocoding with GOOGLE_MAPS_API_KEY)."
+    );
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exitCode = 1;
+});

--- a/scripts/store-profile-machine-tests.ts
+++ b/scripts/store-profile-machine-tests.ts
@@ -160,6 +160,50 @@ async function main() {
     assert.equal(res.status, 409, "owner should not be able to create two stores");
   }
 
+  // Code review / PATCH parity with POST: PATCH must not accept invalid `hours` or `categories`
+  // that POST would reject (e.g. hours: { open: "99:99" }, categories: ["nonexistent"]).
+  {
+    const { res, json } = await patchJson(
+      `/api/stores/${createdStoreId}`,
+      { hours: { open: "99:99", close: "20:00" } },
+      ownerCookie
+    );
+    assert.equal(res.status, 400, "invalid hours should be rejected");
+    const body = json as {
+      error?: string;
+      fieldErrors?: { hours?: string };
+    };
+    assert.equal(body.error, "Validation failed");
+    assert.ok(body.fieldErrors?.hours, "hours field error expected");
+    const afterBadHours = await fetch(`${BASE}/api/stores/${createdStoreId}`);
+    assert.equal(afterBadHours.status, 200);
+    const storeAfter = (await afterBadHours.json()) as {
+      hours: unknown;
+      categories: string[];
+    };
+    assert.deepEqual(storeAfter.hours, { open: "08:00", close: "20:00" });
+    assert.deepEqual(storeAfter.categories, ["produce", "ebt"]);
+  }
+
+  {
+    const { res, json } = await patchJson(
+      `/api/stores/${createdStoreId}`,
+      { categories: ["nonexistent"] },
+      ownerCookie
+    );
+    assert.equal(res.status, 400, "invalid categories should be rejected");
+    const body = json as {
+      error?: string;
+      fieldErrors?: { categories?: string };
+    };
+    assert.equal(body.error, "Validation failed");
+    assert.ok(body.fieldErrors?.categories, "categories field error expected");
+    const afterBadCats = await fetch(`${BASE}/api/stores/${createdStoreId}`);
+    assert.equal(afterBadCats.status, 200);
+    const storeAfter = (await afterBadCats.json()) as { categories: string[] };
+    assert.deepEqual(storeAfter.categories, ["produce", "ebt"]);
+  }
+
   // owner can edit and public data reflects changes
   {
     const { res } = await patchJson(

--- a/scripts/store-profile-machine-tests.ts
+++ b/scripts/store-profile-machine-tests.ts
@@ -1,0 +1,227 @@
+import "dotenv/config";
+import { strict as assert } from "node:assert";
+import { PrismaPg } from "@prisma/adapter-pg";
+import { PrismaClient } from "../app/generated/prisma/client";
+import { fixtureMeta, ids } from "../prisma/fixtures";
+
+const BASE = process.env.TEST_BASE_URL ?? "http://localhost:3000";
+
+const OWNER_PASSWORD = fixtureMeta.ownerPlaintextPassword;
+const OWNER_EMAIL_WITHOUT_STORE = "newowner@no-store.test";
+const OWNER_EMAIL_WITHOUT_STORE_2 = "backupowner@no-store.test";
+const OWNER_EMAIL_EXISTING = "linh@lotus-market.test";
+
+const prisma = new PrismaClient({
+  adapter: new PrismaPg({ connectionString: process.env.DATABASE_URL! }),
+});
+
+function cookiePairHeader(setCookieLines: string[]): string {
+  return setCookieLines
+    .map((line) => line.split(";")[0]?.trim())
+    .filter(Boolean)
+    .join("; ");
+}
+
+async function postJson(path: string, body: unknown, cookieHeader?: string) {
+  const headers: Record<string, string> = { "Content-Type": "application/json" };
+  if (cookieHeader) headers.Cookie = cookieHeader;
+
+  const res = await fetch(`${BASE}${path}`, {
+    method: "POST",
+    headers,
+    body: JSON.stringify(body),
+  });
+  const text = await res.text();
+  let json: unknown = null;
+  try {
+    json = text ? (JSON.parse(text) as unknown) : null;
+  } catch {
+    json = text;
+  }
+  return { res, json, setCookies: res.headers.getSetCookie?.() ?? [] };
+}
+
+async function patchJson(path: string, body: unknown, cookieHeader?: string) {
+  const headers: Record<string, string> = { "Content-Type": "application/json" };
+  if (cookieHeader) headers.Cookie = cookieHeader;
+  const res = await fetch(`${BASE}${path}`, {
+    method: "PATCH",
+    headers,
+    body: JSON.stringify(body),
+  });
+  const text = await res.text();
+  let json: unknown = null;
+  try {
+    json = text ? (JSON.parse(text) as unknown) : null;
+  } catch {
+    json = text;
+  }
+  return { res, json };
+}
+
+async function login(email: string) {
+  const { res, setCookies } = await postJson("/auth/login", {
+    email,
+    password: OWNER_PASSWORD,
+    callbackUrl: "/dashboard",
+  });
+  assert.equal(res.status, 200, `login should succeed for ${email}`);
+  return cookiePairHeader(setCookies);
+}
+
+async function main() {
+  console.log(`Testing store profile story against ${BASE}\n`);
+
+  await prisma.store.deleteMany({
+    where: {
+      ownerId: { in: [ids.owners.noStoreOwner, ids.owners.noStoreOwnerTwo] },
+    },
+  });
+
+  // unauthenticated create blocked
+  {
+    const { res } = await postJson("/api/stores", {
+      name: "No Session Store",
+      address: "123 Main St, Pittsburgh, PA",
+      hours: { open: "08:00", close: "18:00" },
+      categories: ["asian"],
+    });
+    assert.equal(res.status, 401, "POST /api/stores without auth should be 401");
+  }
+
+  const ownerCookie = await login(OWNER_EMAIL_WITHOUT_STORE);
+
+  // required fields validated
+  {
+    const { res, json } = await postJson(
+      "/api/stores",
+      {
+        name: "",
+        address: "",
+        hours: {},
+        categories: [],
+      },
+      ownerCookie
+    );
+    assert.equal(res.status, 400, "missing required fields should fail");
+    const fieldErrors = (json as { fieldErrors?: Record<string, string> }).fieldErrors ?? {};
+    assert.ok(fieldErrors.name, "name should have inline error");
+    assert.ok(fieldErrors.address, "address should have inline error");
+    assert.ok(fieldErrors.hours, "hours should have inline error");
+    assert.ok(fieldErrors.categories, "categories should have inline error");
+  }
+
+  // successful create publishes and geocodes
+  let createdStoreId = "";
+  {
+    const { res, json } = await postJson(
+      "/api/stores",
+      {
+        name: "Casey Corner Grocer",
+        address: "142 Beaver St, Sewickley, PA 15143",
+        hours: { open: "08:00", close: "20:00" },
+        categories: ["produce", "ebt"],
+      },
+      ownerCookie
+    );
+    assert.equal(res.status, 201, "valid create should return 201");
+    const store = (json as { store?: { id: string; lat: number | null; lng: number | null; isPublished: boolean } })
+      .store;
+    assert.ok(store?.id, "created response should include store id");
+    assert.equal(store?.isPublished, true, "created store should be published");
+    assert.equal(typeof store?.lat, "number", "lat should be populated");
+    assert.equal(typeof store?.lng, "number", "lng should be populated");
+    createdStoreId = store!.id;
+  }
+
+  // appears in public directory
+  {
+    const res = await fetch(`${BASE}/api/stores`);
+    assert.equal(res.status, 200, "public stores list should load");
+    const stores = (await res.json()) as Array<{ id: string; name: string }>;
+    assert.ok(
+      stores.some((s) => s.id === createdStoreId && s.name === "Casey Corner Grocer"),
+      "new store should appear in public directory results"
+    );
+  }
+
+  // duplicate create for same owner blocked
+  {
+    const { res } = await postJson(
+      "/api/stores",
+      {
+        name: "Second Store Attempt",
+        address: "123 Second St, Pittsburgh, PA",
+        hours: { open: "09:00", close: "19:00" },
+        categories: ["asian"],
+      },
+      ownerCookie
+    );
+    assert.equal(res.status, 409, "owner should not be able to create two stores");
+  }
+
+  // owner can edit and public data reflects changes
+  {
+    const { res } = await patchJson(
+      `/api/stores/${createdStoreId}`,
+      {
+        name: "Casey Corner Grocer Updated",
+        address: "5000 Forbes Ave, Pittsburgh, PA 15213",
+        hours: { open: "09:00", close: "21:00" },
+        categories: ["organic", "produce"],
+      },
+      ownerCookie
+    );
+    assert.equal(res.status, 200, "owner PATCH should succeed");
+
+    const storeRes = await fetch(`${BASE}/api/stores/${createdStoreId}`);
+    assert.equal(storeRes.status, 200, "public store profile should remain visible");
+    const store = (await storeRes.json()) as { name: string; categories: string[]; address: string };
+    assert.equal(store.name, "Casey Corner Grocer Updated");
+    assert.equal(store.address, "5000 Forbes Ave, Pittsburgh, PA 15213");
+    assert.deepEqual(store.categories, ["organic", "produce"]);
+  }
+
+  // only owner can edit
+  {
+    const otherCookie = await login(OWNER_EMAIL_EXISTING);
+    const { res } = await patchJson(
+      `/api/stores/${createdStoreId}`,
+      { name: "Hacked Store Name" },
+      otherCookie
+    );
+    assert.equal(res.status, 403, "different owner should be forbidden from editing");
+  }
+
+  // second no-store owner can also create
+  {
+    const otherNoStoreCookie = await login(OWNER_EMAIL_WITHOUT_STORE_2);
+    const { res } = await postJson(
+      "/api/stores",
+      {
+        name: "Robin Market",
+        address: "6400 Penn Ave, Pittsburgh, PA 15206",
+        hours: { open: "07:30", close: "18:30" },
+        categories: ["asian"],
+      },
+      otherNoStoreCookie
+    );
+    assert.equal(res.status, 201, "another authenticated owner should be able to create");
+  }
+
+  console.log("All machine store-profile tests passed.");
+}
+
+main()
+  .catch((err) => {
+    console.error(err);
+    process.exitCode = 1;
+  })
+  .finally(async () => {
+    await prisma.store.deleteMany({
+      where: {
+        ownerId: { in: [ids.owners.noStoreOwner, ids.owners.noStoreOwnerTwo] },
+      },
+    });
+    await prisma.$disconnect();
+  });


### PR DESCRIPTION
## Summary

**Closes #3 (Create Store Profile) :** End-to-end store profile creation/edit flow with validation, geocoding + resilient fallback behavior, owner-only authorization, and machine-runnable HTTP tests.

- **Store profile create API** — Implemented `POST /api/stores` with auth requirement, required-field validation (`name`, `address`, `hours`, `categories`), duplicate-owner guard, and persisted `lat/lng` geocoding output.
- **Store profile update API** — Extended `PATCH /api/stores/[id]` with owner-only protection, publishing constraints, and re-geocoding when address changes on published stores.
- **Validation layer** — Added shared store-profile input validation (`lib/store-profile.ts`) with clear `fieldErrors` for inline UI messages.
- **Geocoding layer** — Added `lib/geocode-address.ts` (Google Geocoding first, deterministic Pittsburgh fallback when API key is missing or Google response fails), with logs to surface fallback usage.
- **UI** — Replaced static profile mock with a working create/edit form (`StoreProfileForm`) supporting inline validation messages, publish/draft actions, and refresh-on-save.
- **Machine tests** — Added `scripts/store-profile-machine-tests.ts` + `npm run test:store-profile` for create/edit acceptance scenarios and authorization checks.
- **Geocoding tests** — Added `scripts/geocode-branch-tests.ts` + `npm run test:geocode` for mocked branch coverage (Google success/failure + no-key fallback) and optional real API integration check with `GEOCODE_LIVE_TEST=1`.
- **Docs** — Updated README with geocode test instructions and script references.

---

## Acceptance Criteria

- [x] Creating a store requires `name`, `address`, `hours`, and at least one specialty category  
- [x] The system validates required fields before publishing and returns field-level errors  
- [x] Address is converted into map-friendly `lat/lng` before store is shown publicly  
- [x] Only authenticated owners can create a store profile  
- [x] Owners can edit profile details and changes are reflected publicly  
- [x] Non-owners cannot edit another owner’s store (`403`), unauthenticated requests get `401`  
- [x] New valid store appears in public directory (`GET /api/stores`)  
- [x] Geocoding Google-success and fallback branches are testable (`npm run test:geocode`)  
- [x] `npm run test:store-profile` passes against running app + migrated + seeded DB  
- [x] `npm run test:auth` passes (regression coverage)

---

## Files Changed

| Area | Files |
|------|--------|
| **Store profile UI** | `app/(dashboard)/dashboard/profile/page.tsx`, `app/(dashboard)/dashboard/profile/StoreProfileForm.tsx` |
| **Store APIs** | `app/api/stores/route.ts`, `app/api/stores/[id]/route.ts` |
| **Geocoding + validation** | `lib/geocode-address.ts`, `lib/store-profile.ts` |
| **Tests** | `scripts/store-profile-machine-tests.ts`, `scripts/geocode-branch-tests.ts` |
| **Config / docs** | `package.json`, `README.md` |