### PR TITLE
feat: Add store inventory search with fuzzy matching + restock “Notify me” alerts

### DIFF
--- a/app/(public)/stores/[id]/page.tsx
+++ b/app/(public)/stores/[id]/page.tsx
@@ -5,6 +5,7 @@
 import { prisma } from "@/lib/prisma";
 import { notFound } from "next/navigation";
 import Link from "next/link";
+import ItemAvailabilitySearch from "@/components/ItemAvailabilitySearch";
 
 function timeAgo(date: Date): string {
   const ms = Date.now() - new Date(date).getTime();
@@ -93,6 +94,12 @@ export default async function StoreProfilePage({
           )}
         </div>
       </div>
+
+      <ItemAvailabilitySearch
+        storeId={store.id}
+        storeName={store.name}
+        storeAddress={store.address}
+      />
 
       {/* Fresh Today — Story 1 */}
       <div className="bg-white rounded-2xl border border-gray-200 p-6 mb-4">

--- a/app/api/alerts/[id]/route.ts
+++ b/app/api/alerts/[id]/route.ts
@@ -1,6 +1,35 @@
-import { NextResponse } from "next/server";
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
 
 // Story 5: DELETE /api/alerts/:id — Deactivate alert (shopper auth required)
-export async function DELETE() {
-  return NextResponse.json({ message: "TODO: Delete alert" }, { status: 501 });
+export async function DELETE(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const shopperId =
+      req.headers.get("x-shopper-id") ?? req.nextUrl.searchParams.get("shopperId");
+    if (!shopperId) {
+      return NextResponse.json(
+        { error: "shopperId is required" },
+        { status: 400 }
+      );
+    }
+
+    const { id } = await params;
+    const existing = await prisma.alert.findUnique({ where: { id } });
+    if (!existing || existing.shopperId !== shopperId) {
+      return NextResponse.json({ error: "Alert not found" }, { status: 404 });
+    }
+
+    const alert = await prisma.alert.update({
+      where: { id },
+      data: { isActive: false },
+    });
+
+    return NextResponse.json(alert);
+  } catch (error) {
+    console.error("DELETE /api/alerts/:id error:", error);
+    return NextResponse.json({ error: "Failed to delete alert" }, { status: 500 });
+  }
 }

--- a/app/api/alerts/route.ts
+++ b/app/api/alerts/route.ts
@@ -1,11 +1,103 @@
-import { NextResponse } from "next/server";
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { AlertType } from "@/app/generated/prisma/client";
+
+function getShopperId(req: NextRequest): string | null {
+  return (
+    req.headers.get("x-shopper-id") ??
+    req.nextUrl.searchParams.get("shopperId") ??
+    null
+  );
+}
 
 // Story 5: GET /api/alerts — List own active alerts (shopper auth required)
-export async function GET() {
-  return NextResponse.json({ message: "TODO: List alerts" }, { status: 501 });
+export async function GET(req: NextRequest) {
+  try {
+    const shopperId = getShopperId(req);
+    if (!shopperId) {
+      return NextResponse.json(
+        { error: "shopperId is required" },
+        { status: 400 }
+      );
+    }
+
+    const alerts = await prisma.alert.findMany({
+      where: { shopperId, isActive: true },
+      orderBy: { createdAt: "desc" },
+    });
+
+    return NextResponse.json(alerts);
+  } catch (error) {
+    console.error("GET /api/alerts error:", error);
+    return NextResponse.json({ error: "Failed to list alerts" }, { status: 500 });
+  }
 }
 
 // Story 5: POST /api/alerts — Create alert (item_restock or store_follow)
-export async function POST() {
-  return NextResponse.json({ message: "TODO: Create alert" }, { status: 501 });
+export async function POST(req: NextRequest) {
+  try {
+    const body = (await req.json()) as {
+      shopperId?: string;
+      itemId?: string | null;
+      storeId?: string | null;
+      type?: string;
+    };
+
+    const shopperId = body.shopperId ?? getShopperId(req);
+    if (!shopperId) {
+      return NextResponse.json(
+        { error: "shopperId is required" },
+        { status: 400 }
+      );
+    }
+
+    if (body.type !== AlertType.item_restock && body.type !== AlertType.store_follow) {
+      return NextResponse.json(
+        { error: "type must be item_restock or store_follow" },
+        { status: 400 }
+      );
+    }
+
+    if (body.type === AlertType.item_restock && !body.itemId) {
+      return NextResponse.json(
+        { error: "itemId is required for item_restock alerts" },
+        { status: 400 }
+      );
+    }
+
+    if (body.type === AlertType.store_follow && !body.storeId) {
+      return NextResponse.json(
+        { error: "storeId is required for store_follow alerts" },
+        { status: 400 }
+      );
+    }
+
+    const existing = await prisma.alert.findFirst({
+      where: {
+        shopperId,
+        type: body.type,
+        itemId: body.itemId ?? null,
+        storeId: body.storeId ?? null,
+      },
+    });
+
+    const alert = existing
+      ? await prisma.alert.update({
+          where: { id: existing.id },
+          data: { isActive: true },
+        })
+      : await prisma.alert.create({
+          data: {
+            shopperId,
+            type: body.type,
+            itemId: body.itemId ?? null,
+            storeId: body.storeId ?? null,
+          },
+        });
+
+    return NextResponse.json(alert, { status: 201 });
+  } catch (error) {
+    console.error("POST /api/alerts error:", error);
+    return NextResponse.json({ error: "Failed to create alert" }, { status: 500 });
+  }
 }

--- a/app/api/stores/[id]/items/route.ts
+++ b/app/api/stores/[id]/items/route.ts
@@ -1,8 +1,155 @@
-import { NextResponse } from "next/server";
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+
+const MAX_RESULTS = 50;
+const MAX_CANDIDATES = 250;
+
+function normalizeForSearch(value: string): string {
+  return value
+    .toLowerCase()
+    .replace(/[^a-z0-9\s]/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function levenshteinDistance(a: string, b: string): number {
+  if (a === b) return 0;
+  if (a.length === 0) return b.length;
+  if (b.length === 0) return a.length;
+
+  const row = new Array(b.length + 1).fill(0);
+  for (let j = 0; j <= b.length; j += 1) {
+    row[j] = j;
+  }
+
+  for (let i = 1; i <= a.length; i += 1) {
+    let previousDiagonal = row[0];
+    row[0] = i;
+    for (let j = 1; j <= b.length; j += 1) {
+      const cached = row[j];
+      const cost = a[i - 1] === b[j - 1] ? 0 : 1;
+      row[j] = Math.min(row[j] + 1, row[j - 1] + 1, previousDiagonal + cost);
+      previousDiagonal = cached;
+    }
+  }
+
+  return row[b.length];
+}
 
 // Story 5: GET /api/stores/:id/items?q=bok+choy — Search items with fuzzy matching
-export async function GET() {
-  return NextResponse.json({ message: "TODO: Search items" }, { status: 501 });
+export async function GET(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const { id: storeId } = await params;
+    const q = req.nextUrl.searchParams.get("q")?.trim() ?? "";
+    const location = req.nextUrl.searchParams.get("location")?.trim() ?? "";
+
+    if (q.length === 0) {
+      return NextResponse.json([]);
+    }
+
+    const query = normalizeForSearch(q);
+    if (query.length === 0) {
+      return NextResponse.json([]);
+    }
+
+    const [store, directMatches, broadMatches] = await Promise.all([
+      prisma.store.findUnique({
+        where: { id: storeId },
+        select: { id: true, address: true, name: true, isPublished: true },
+      }),
+      prisma.item.findMany({
+        where: {
+          storeId,
+          OR: [
+            { name: { contains: q, mode: "insensitive" } },
+            { name: { contains: query, mode: "insensitive" } },
+          ],
+        },
+        select: {
+          id: true,
+          name: true,
+          inStock: true,
+          lastUpdated: true,
+          store: { select: { id: true, name: true, address: true } },
+        },
+        take: MAX_CANDIDATES,
+      }),
+      prisma.item.findMany({
+        where: { storeId },
+        select: {
+          id: true,
+          name: true,
+          inStock: true,
+          lastUpdated: true,
+          store: { select: { id: true, name: true, address: true } },
+        },
+        take: MAX_CANDIDATES,
+      }),
+    ]);
+
+    if (!store || !store.isPublished) {
+      return NextResponse.json({ error: "Store not found" }, { status: 404 });
+    }
+
+    const locationQuery = normalizeForSearch(location);
+    if (
+      locationQuery &&
+      !normalizeForSearch(`${store.name} ${store.address}`).includes(locationQuery)
+    ) {
+      return NextResponse.json([]);
+    }
+
+    const deduped = new Map<string, (typeof directMatches)[number]>();
+    for (const item of [...directMatches, ...broadMatches]) {
+      deduped.set(item.id, item);
+    }
+
+    const scored = Array.from(deduped.values())
+      .map((item) => {
+        const normalizedName = normalizeForSearch(item.name);
+        const tokenDistances = normalizedName
+          .split(" ")
+          .filter(Boolean)
+          .map((token) => levenshteinDistance(query, token));
+
+        const fullDistance = levenshteinDistance(query, normalizedName);
+        const minDistance = Math.min(fullDistance, ...tokenDistances);
+        const includesQuery = normalizedName.includes(query);
+
+        return {
+          ...item,
+          matchScore: includesQuery ? 0 : minDistance,
+        };
+      })
+      .filter((item) => item.matchScore <= 2 || normalizeForSearch(item.name).includes(query))
+      .sort((a, b) => {
+        if (a.matchScore !== b.matchScore) return a.matchScore - b.matchScore;
+        if (a.inStock !== b.inStock) return Number(b.inStock) - Number(a.inStock);
+        return a.name.localeCompare(b.name);
+      })
+      .slice(0, MAX_RESULTS)
+      .map((item) => ({
+        id: item.id,
+        name: item.name,
+        stock_count: item.inStock ? 1 : 0,
+        in_stock: item.inStock,
+        store_id: item.store.id,
+        store_name: item.store.name,
+        store_location: item.store.address,
+        last_updated: item.lastUpdated.toISOString(),
+      }));
+
+    return NextResponse.json(scored);
+  } catch (error) {
+    console.error("GET /api/stores/:id/items error:", error);
+    return NextResponse.json(
+      { error: "Failed to search store items" },
+      { status: 500 }
+    );
+  }
 }
 
 // Story 7: POST /api/stores/:id/items — Create an item

--- a/components/ItemAvailabilitySearch.tsx
+++ b/components/ItemAvailabilitySearch.tsx
@@ -1,0 +1,200 @@
+"use client";
+
+import { useMemo, useState } from "react";
+
+type SearchResult = {
+  id: string;
+  name: string;
+  stock_count: number;
+  in_stock: boolean;
+  store_id: string;
+  store_name: string;
+  store_location: string;
+  last_updated: string;
+};
+
+type Props = {
+  storeId: string;
+  storeName: string;
+  storeAddress: string;
+};
+
+const DEMO_SHOPPER_ID = "55555555-5555-5555-5555-555555555555";
+
+function toRelativeTime(isoDate: string): string {
+  const timestamp = new Date(isoDate).getTime();
+  if (Number.isNaN(timestamp)) return "updated recently";
+
+  const diffMs = timestamp - Date.now();
+  const absMs = Math.abs(diffMs);
+  const rtf = new Intl.RelativeTimeFormat("en", { numeric: "auto" });
+
+  const minute = 60_000;
+  const hour = 60 * minute;
+  const day = 24 * hour;
+
+  if (absMs < hour) {
+    const minutes = Math.max(1, Math.round(diffMs / minute));
+    return rtf.format(minutes, "minute");
+  }
+  if (absMs < day) {
+    const hours = Math.round(diffMs / hour);
+    return rtf.format(hours, "hour");
+  }
+  const days = Math.round(diffMs / day);
+  return rtf.format(days, "day");
+}
+
+export default function ItemAvailabilitySearch({
+  storeId,
+  storeName,
+  storeAddress,
+}: Props) {
+  const [query, setQuery] = useState("");
+  const [results, setResults] = useState<SearchResult[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [searched, setSearched] = useState(false);
+  const [notifyByItemId, setNotifyByItemId] = useState<Record<string, boolean>>({});
+
+  const hasQuery = query.trim().length > 0;
+  const queryHint = useMemo(() => (hasQuery ? query.trim() : ""), [hasQuery, query]);
+
+  async function runSearch(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    if (!hasQuery) return;
+
+    setLoading(true);
+    setSearched(true);
+    try {
+      const params = new URLSearchParams({
+        q: query.trim(),
+        location: storeAddress,
+      });
+      const response = await fetch(`/api/stores/${storeId}/items?${params.toString()}`);
+      if (!response.ok) {
+        setResults([]);
+        return;
+      }
+      const data = (await response.json()) as SearchResult[];
+      setResults(data);
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  async function toggleNotify(item: SearchResult) {
+    const currentlyOn = Boolean(notifyByItemId[item.id]);
+    if (!currentlyOn) {
+      const res = await fetch("/api/alerts", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          shopperId: DEMO_SHOPPER_ID,
+          type: "item_restock",
+          itemId: item.id,
+          storeId: item.store_id,
+        }),
+      });
+      if (res.ok) {
+        setNotifyByItemId((prev) => ({ ...prev, [item.id]: true }));
+      }
+      return;
+    }
+
+    const listRes = await fetch(`/api/alerts?shopperId=${DEMO_SHOPPER_ID}`);
+    if (!listRes.ok) return;
+    const alerts = (await listRes.json()) as Array<{
+      id: string;
+      itemId: string | null;
+      type: string;
+    }>;
+    const existing = alerts.find(
+      (alert) => alert.type === "item_restock" && alert.itemId === item.id
+    );
+    if (!existing) {
+      setNotifyByItemId((prev) => ({ ...prev, [item.id]: false }));
+      return;
+    }
+
+    const deleteRes = await fetch(
+      `/api/alerts/${existing.id}?shopperId=${DEMO_SHOPPER_ID}`,
+      { method: "DELETE" }
+    );
+    if (deleteRes.ok) {
+      setNotifyByItemId((prev) => ({ ...prev, [item.id]: false }));
+    }
+  }
+
+  return (
+    <div className="bg-white rounded-2xl border border-gray-200 p-6 mb-4">
+      <h2 className="text-[17px] font-semibold text-gray-800 mb-1.5">
+        Search Inventory
+      </h2>
+      <p className="text-[13px] text-gray-500 mb-4">
+        Check {storeName} stock before you head out.
+      </p>
+
+      <form onSubmit={runSearch} className="flex flex-col sm:flex-row gap-2.5 mb-5">
+        <input
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          placeholder="Try: bok choy, shin ramen"
+          className="flex-1 px-3.5 py-2.5 rounded-md border-[1.5px] border-gray-200 text-[15px] bg-white outline-none focus:border-green-400 transition-colors"
+        />
+        <button
+          type="submit"
+          disabled={!hasQuery || loading}
+          className="px-4 py-2.5 rounded-md text-sm font-medium text-white bg-green-600 hover:bg-green-700 disabled:bg-green-300 transition-colors"
+        >
+          {loading ? "Searching..." : "Search"}
+        </button>
+      </form>
+
+      {searched && !loading && results.length === 0 && (
+        <p className="text-[14px] text-gray-500">
+          No matches found for &quot;{queryHint}&quot; at this location.
+        </p>
+      )}
+
+      <div className="space-y-2.5">
+        {results.map((item) => (
+          <div
+            key={item.id}
+            className="border border-gray-200 rounded-xl px-3.5 py-3 flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3"
+          >
+            <div className="min-w-0">
+              <div className="font-medium text-[15px] text-gray-800">{item.name}</div>
+              <div className="text-[12px] text-gray-500 mt-0.5">
+                Updated {toRelativeTime(item.last_updated)} (
+                {new Date(item.last_updated).toISOString()})
+              </div>
+            </div>
+
+            <div className="flex items-center gap-2.5 shrink-0">
+              <span
+                className={`text-[12px] px-2.5 py-1 rounded-full font-medium ${
+                  item.stock_count === 0
+                    ? "bg-red-50 text-red-700"
+                    : "bg-green-50 text-green-700"
+                }`}
+              >
+                {item.stock_count === 0 ? "Out of Stock" : "In-Stock"}
+              </span>
+              <button
+                type="button"
+                onClick={() => toggleNotify(item)}
+                className={`text-[12px] px-2.5 py-1 rounded-full border transition-colors ${
+                  notifyByItemId[item.id]
+                    ? "border-green-300 bg-green-50 text-green-700"
+                    : "border-gray-200 bg-white text-gray-600 hover:border-green-300 hover:text-green-700"
+                }`}
+              >
+                {notifyByItemId[item.id] ? "Notify me: On" : "Notify me"}
+              </button>
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
### PR Description
This PR enables shoppers to quickly check whether a specific local store has an item in stock, with spelling-tolerant search and visible stock trust signals (badges + last-updated timestamps). It also adds a per-item “Notify me” toggle that creates/deactivates item restock alerts.

### Key changes

- **Inventory search API: `GET /api/stores/:id/items?q=...&location=...`**
  - Fuzzy matching using Levenshtein distance ≤ 2
  - Returns `stock_count` (0/1) and ISO 8601 `last_updated` for every match
- **Alerts support:**
  - `GET /api/alerts?shopperId=...` to list active alerts
  - `POST /api/alerts` to create/reactivate item restock alerts
  - `DELETE /api/alerts/:id` to deactivate alerts
- **Store page UI:**
  - Adds “Search Inventory” panel on `stores/[id]`
  - Displays In-Stock / Out of Stock badges
  - Renders `last_updated` as a relative time string and includes the ISO timestamp
  - Adds “Notify me” toggle per item

### Files

- `app/api/stores/[id]/items/route.ts`
- `components/ItemAvailabilitySearch.tsx`
- `app/(public)/stores/[id]/page.tsx`
- `app/api/alerts/route.ts`
- `app/api/alerts/[id]/route.ts`

### How to test
Run:

- `npm run dev`
- Open a store and use Search Inventory (examples from seeded data):
- Search bok choy (expect in-stock + out-of-stock variants)
- Search a misspelling (expect fuzzy results)
- Toggle Notify me for an item:
- First click turns it on, second click turns it off

### Known note (for reviewers)
The UI toggle uses a demo shopperId in the component (so it works end-to-end immediately without full shopper auth wiring).
-  In the file`components/ItemAvailabilitySearch.tsx`, is we hard-coded: `const DEMO_SHOPPER_ID = "55555555-5555-5555-5555-555555555555";` to check if it works. 