### PR TITLE
feat: add owner post management (edit/delete + realtime updates) and deal editing

### DIFF
--- a/app/(dashboard)/dashboard/deals/ManageDealsClient.tsx
+++ b/app/(dashboard)/dashboard/deals/ManageDealsClient.tsx
@@ -20,6 +20,10 @@ function dateInputToIso(dateStr: string): string {
   return new Date(Date.UTC(y, m - 1, d, 23, 59, 59, 999)).toISOString();
 }
 
+function isoToDateInput(iso: string): string {
+  return new Date(iso).toISOString().slice(0, 10);
+}
+
 function dealIsActive(d: ApiDeal): boolean {
   return !d.isExpired && new Date(d.expiresAt).getTime() > Date.now();
 }
@@ -42,6 +46,12 @@ export default function ManageDealsClient({ storeId }: { storeId: string }) {
   const [submitting, setSubmitting] = useState(false);
   const [reuseDates, setReuseDates] = useState<Record<string, string>>({});
   const [pastDealsVisible, setPastDealsVisible] = useState(PAST_DEALS_PAGE_SIZE);
+  const [editingDealId, setEditingDealId] = useState<string | null>(null);
+  const [editPrice, setEditPrice] = useState("");
+  const [editDescription, setEditDescription] = useState("");
+  const [editTitle, setEditTitle] = useState("");
+  const [editExpiresDate, setEditExpiresDate] = useState("");
+  const [savingEdit, setSavingEdit] = useState(false);
 
   const load = useCallback(async () => {
     setLoadError(null);
@@ -147,10 +157,131 @@ export default function ManageDealsClient({ storeId }: { storeId: string }) {
     await load();
   }
 
+  function beginEdit(deal: ApiDeal) {
+    setError(null);
+    setEditingDealId(deal.id);
+    setEditPrice(deal.price ?? "");
+    setEditDescription(deal.description ?? "");
+    setEditTitle(deal.title);
+    setEditExpiresDate(isoToDateInput(deal.expiresAt));
+  }
+
+  function cancelEdit() {
+    setEditingDealId(null);
+    setEditPrice("");
+    setEditDescription("");
+    setEditTitle("");
+    setEditExpiresDate("");
+  }
+
+  async function saveEdit(dealId: string) {
+    setError(null);
+    if (!editPrice.trim()) {
+      setError("Price is required.");
+      return;
+    }
+    if (!editDescription.trim()) {
+      setError("Description is required.");
+      return;
+    }
+    if (!editExpiresDate) {
+      setError("Expiry date is required.");
+      return;
+    }
+
+    setSavingEdit(true);
+    try {
+      const res = await fetch(`/api/stores/${storeId}/deals/${dealId}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          price: editPrice.trim(),
+          description: editDescription,
+          title: editTitle.trim(),
+          expires_at: dateInputToIso(editExpiresDate),
+        }),
+      });
+      const data = await res.json().catch(() => ({}));
+      if (!res.ok) {
+        setError(typeof data.error === "string" ? data.error : "Could not update deal.");
+        return;
+      }
+      cancelEdit();
+      await load();
+    } finally {
+      setSavingEdit(false);
+    }
+  }
+
   const activeDeals = deals.filter(dealIsActive);
   const inactiveDeals = deals.filter((d) => !dealIsActive(d));
   const visibleInactive = inactiveDeals.slice(0, pastDealsVisible);
   const hasMorePast = inactiveDeals.length > pastDealsVisible;
+
+  function renderEditingCard(dealId: string) {
+    return (
+      <div className="p-3.5 bg-white border border-green-200 rounded-xl">
+        <div className="space-y-3">
+          <div>
+            <label className="block text-[12px] font-medium text-gray-600 mb-1">Price (USD)</label>
+            <input
+              type="number"
+              min={0.01}
+              step="0.01"
+              value={editPrice}
+              onChange={(e) => setEditPrice(e.target.value)}
+              className="w-full px-3 py-2 rounded-md border border-gray-200 text-[14px] outline-none focus:border-green-400"
+            />
+          </div>
+          <div>
+            <label className="block text-[12px] font-medium text-gray-600 mb-1">Description</label>
+            <textarea
+              rows={3}
+              value={editDescription}
+              onChange={(e) => setEditDescription(e.target.value)}
+              className="w-full px-3 py-2 rounded-md border border-gray-200 text-[14px] outline-none focus:border-green-400 resize-y"
+            />
+          </div>
+          <div>
+            <label className="block text-[12px] font-medium text-gray-600 mb-1">
+              Short title (optional)
+            </label>
+            <input
+              value={editTitle}
+              onChange={(e) => setEditTitle(e.target.value)}
+              className="w-full px-3 py-2 rounded-md border border-gray-200 text-[14px] outline-none focus:border-green-400"
+            />
+          </div>
+          <div>
+            <label className="block text-[12px] font-medium text-gray-600 mb-1">Expiry date</label>
+            <input
+              type="date"
+              value={editExpiresDate}
+              onChange={(e) => setEditExpiresDate(e.target.value)}
+              className="w-full px-3 py-2 rounded-md border border-gray-200 text-[14px] outline-none focus:border-green-400"
+            />
+          </div>
+          <div className="flex justify-end gap-2">
+            <button
+              type="button"
+              onClick={cancelEdit}
+              className="px-3 py-1.5 rounded-md text-[12px] font-medium border border-gray-200 hover:bg-gray-100 transition-colors text-gray-600"
+            >
+              Cancel
+            </button>
+            <button
+              type="button"
+              disabled={savingEdit}
+              onClick={() => saveEdit(dealId)}
+              className="px-3 py-1.5 rounded-md text-[12px] font-medium border border-green-200 bg-green-50 text-green-700 hover:bg-green-100 transition-colors disabled:opacity-50"
+            >
+              {savingEdit ? "Saving..." : "Save"}
+            </button>
+          </div>
+        </div>
+      </div>
+    );
+  }
 
   return (
     <>
@@ -251,72 +382,96 @@ export default function ManageDealsClient({ storeId }: { storeId: string }) {
         <p className="text-[14px] text-gray-400">No deals yet. Post your first one above.</p>
       ) : (
         <div className="space-y-2">
-          {activeDeals.map((deal) => (
-            <div
-              key={deal.id}
-              className="flex items-center gap-3 p-3.5 bg-white border border-gray-200 rounded-xl hover:border-gray-400 transition-colors"
-            >
-              <div className="text-2xl w-11 h-11 rounded-md bg-gray-50 flex items-center justify-center shrink-0">
-                🏷
-              </div>
-              <div className="flex-1 min-w-0">
-                <div className="font-medium text-[15px] truncate">{deal.title}</div>
-                <div className="text-[12px] text-gray-400 mt-0.5">{formatDealMeta(deal)}</div>
-              </div>
-              <button
-                type="button"
-                onClick={() => removeDeal(deal.id)}
-                className="shrink-0 px-2.5 py-1 rounded-md text-[12px] font-medium text-gray-500 border border-gray-200 hover:bg-red-50 hover:text-red-700 hover:border-red-100 transition-colors"
+          {activeDeals.map((deal) =>
+            editingDealId === deal.id ? (
+              <div key={deal.id}>{renderEditingCard(deal.id)}</div>
+            ) : (
+              <div
+                key={deal.id}
+                className="flex items-center gap-3 p-3.5 bg-white border border-gray-200 rounded-xl hover:border-gray-400 transition-colors"
               >
-                Remove
-              </button>
-            </div>
-          ))}
-          {visibleInactive.map((deal) => (
-            <div
-              key={deal.id}
-              className="flex flex-col sm:flex-row sm:items-center gap-3 p-3.5 bg-white border border-gray-200 rounded-xl opacity-80"
-            >
-              <div className="text-2xl w-11 h-11 rounded-md bg-gray-50 flex items-center justify-center shrink-0">
-                🏷
-              </div>
-              <div className="flex-1 min-w-0">
-                <div className="font-medium text-[15px] truncate line-through">{deal.title}</div>
-                <div className="text-[12px] text-gray-400 mt-0.5">
-                  {deal.isExpired || new Date(deal.expiresAt) <= new Date()
-                    ? "Expired — hidden from shoppers"
-                    : "Inactive"}
-                  {" · "}
-                  {formatDealMeta(deal)}
+                <div className="text-2xl w-11 h-11 rounded-md bg-gray-50 flex items-center justify-center shrink-0">
+                  🏷
                 </div>
-              </div>
-              <div className="flex flex-col gap-2 shrink-0 w-full sm:w-auto">
-                <input
-                  type="date"
-                  value={reuseDates[deal.id] ?? ""}
-                  onChange={(e) =>
-                    setReuseDates((prev) => ({ ...prev, [deal.id]: e.target.value }))
-                  }
-                  className="px-2 py-1.5 rounded-md border border-gray-200 text-[13px]"
-                />
-                <div className="flex flex-wrap gap-2">
+                <div className="flex-1 min-w-0">
+                  <div className="font-medium text-[15px] truncate">{deal.title}</div>
+                  <div className="text-[12px] text-gray-400 mt-0.5">{formatDealMeta(deal)}</div>
+                </div>
+                <div className="flex gap-2 shrink-0">
                   <button
                     type="button"
-                    onClick={() => reuseDeal(deal.id)}
-                    className="px-3 py-1.5 rounded-md text-[12px] font-medium border border-gray-200 hover:bg-green-50 hover:text-green-700 hover:border-green-200 transition-colors text-gray-600"
+                    onClick={() => beginEdit(deal)}
+                    className="px-2.5 py-1 rounded-md text-[12px] font-medium text-gray-500 border border-gray-200 hover:bg-gray-100 transition-colors"
                   >
-                    Reuse with new expiry
+                    Edit
                   </button>
                   <button
                     type="button"
                     onClick={() => removeDeal(deal.id)}
-                    className="px-3 py-1.5 rounded-md text-[12px] font-medium border border-gray-200 text-gray-500 hover:bg-red-50 hover:text-red-700 hover:border-red-100 transition-colors"
+                    className="px-2.5 py-1 rounded-md text-[12px] font-medium text-gray-500 border border-gray-200 hover:bg-red-50 hover:text-red-700 hover:border-red-100 transition-colors"
                   >
                     Remove
                   </button>
                 </div>
               </div>
-            </div>
+            ),
+          )}
+          {visibleInactive.map((deal) => (
+            editingDealId === deal.id ? (
+              <div key={deal.id}>{renderEditingCard(deal.id)}</div>
+            ) : (
+              <div
+                key={deal.id}
+                className="flex flex-col sm:flex-row sm:items-center gap-3 p-3.5 bg-white border border-gray-200 rounded-xl opacity-80"
+              >
+                <div className="text-2xl w-11 h-11 rounded-md bg-gray-50 flex items-center justify-center shrink-0">
+                  🏷
+                </div>
+                <div className="flex-1 min-w-0">
+                  <div className="font-medium text-[15px] truncate line-through">{deal.title}</div>
+                  <div className="text-[12px] text-gray-400 mt-0.5">
+                    {deal.isExpired || new Date(deal.expiresAt) <= new Date()
+                      ? "Expired — hidden from shoppers"
+                      : "Inactive"}
+                    {" · "}
+                    {formatDealMeta(deal)}
+                  </div>
+                </div>
+                <div className="flex flex-col gap-2 shrink-0 w-full sm:w-auto">
+                  <input
+                    type="date"
+                    value={reuseDates[deal.id] ?? ""}
+                    onChange={(e) =>
+                      setReuseDates((prev) => ({ ...prev, [deal.id]: e.target.value }))
+                    }
+                    className="px-2 py-1.5 rounded-md border border-gray-200 text-[13px]"
+                  />
+                  <div className="flex flex-wrap gap-2">
+                    <button
+                      type="button"
+                      onClick={() => beginEdit(deal)}
+                      className="px-3 py-1.5 rounded-md text-[12px] font-medium border border-gray-200 hover:bg-gray-100 transition-colors text-gray-600"
+                    >
+                      Edit
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => reuseDeal(deal.id)}
+                      className="px-3 py-1.5 rounded-md text-[12px] font-medium border border-gray-200 hover:bg-green-50 hover:text-green-700 hover:border-green-200 transition-colors text-gray-600"
+                    >
+                      Reuse with new expiry
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => removeDeal(deal.id)}
+                      className="px-3 py-1.5 rounded-md text-[12px] font-medium border border-gray-200 text-gray-500 hover:bg-red-50 hover:text-red-700 hover:border-red-100 transition-colors"
+                    >
+                      Remove
+                    </button>
+                  </div>
+                </div>
+              </div>
+            )
           ))}
           {hasMorePast && (
             <button

--- a/app/(dashboard)/dashboard/posts/ManagePostsClient.tsx
+++ b/app/(dashboard)/dashboard/posts/ManagePostsClient.tsx
@@ -1,0 +1,311 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { relativeTime } from "@/lib/time";
+
+type ApiPost = {
+  id: string;
+  itemName: string;
+  note: string | null;
+  createdAt: string;
+};
+
+type EditState = {
+  itemName: string;
+  note: string;
+};
+
+export default function ManagePostsClient({ storeId }: { storeId: string }) {
+  const [posts, setPosts] = useState<ApiPost[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const [itemName, setItemName] = useState("");
+  const [note, setNote] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+
+  const [editingPostId, setEditingPostId] = useState<string | null>(null);
+  const [editDraft, setEditDraft] = useState<EditState>({ itemName: "", note: "" });
+  const [savingEdit, setSavingEdit] = useState(false);
+
+  const load = useCallback(async () => {
+    setLoadError(null);
+    const res = await fetch(`/api/stores/${storeId}/posts`);
+    if (!res.ok) {
+      let message = "Could not load posts. Refresh the page or sign in again.";
+      try {
+        const data = (await res.json()) as { error?: string };
+        if (typeof data.error === "string" && data.error) message = data.error;
+      } catch {
+        // Ignore body parse errors.
+      }
+      setLoadError(message);
+      setPosts([]);
+      return;
+    }
+    const data = await res.json();
+    setPosts(data.posts ?? []);
+  }, [storeId]);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    (async () => {
+      try {
+        await load();
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [load]);
+
+  async function submitNewPost(e: React.FormEvent) {
+    e.preventDefault();
+    setError(null);
+    if (!itemName.trim()) {
+      setError("Item name is required.");
+      return;
+    }
+
+    setSubmitting(true);
+    try {
+      const res = await fetch(`/api/stores/${storeId}/posts`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          item_name: itemName.trim(),
+          note: note.trim() || null,
+        }),
+      });
+
+      const data = await res.json().catch(() => ({}));
+      if (!res.ok) {
+        setError(typeof data.error === "string" ? data.error : "Could not create post.");
+        return;
+      }
+
+      setItemName("");
+      setNote("");
+      await load();
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  function beginEdit(post: ApiPost) {
+    setError(null);
+    setEditingPostId(post.id);
+    setEditDraft({
+      itemName: post.itemName,
+      note: post.note ?? "",
+    });
+  }
+
+  function cancelEdit() {
+    setEditingPostId(null);
+    setEditDraft({ itemName: "", note: "" });
+  }
+
+  async function saveEdit(postId: string) {
+    setError(null);
+    if (!editDraft.itemName.trim()) {
+      setError("Item name cannot be empty.");
+      return;
+    }
+
+    setSavingEdit(true);
+    try {
+      const res = await fetch(`/api/stores/${storeId}/posts/${postId}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          item_name: editDraft.itemName.trim(),
+          note: editDraft.note.trim() || null,
+        }),
+      });
+      const data = await res.json().catch(() => ({}));
+      if (!res.ok) {
+        setError(typeof data.error === "string" ? data.error : "Could not save post changes.");
+        return;
+      }
+      setEditingPostId(null);
+      await load();
+    } finally {
+      setSavingEdit(false);
+    }
+  }
+
+  async function deletePost(postId: string) {
+    setError(null);
+    const confirmed = window.confirm("Delete this post? Shoppers will stop seeing it immediately.");
+    if (!confirmed) return;
+
+    const res = await fetch(`/api/stores/${storeId}/posts/${postId}`, {
+      method: "DELETE",
+    });
+    const data = await res.json().catch(() => ({}));
+    if (!res.ok) {
+      setError(typeof data.error === "string" ? data.error : "Could not delete post.");
+      return;
+    }
+    if (editingPostId === postId) cancelEdit();
+    await load();
+  }
+
+  return (
+    <>
+      <div className="bg-white rounded-2xl border border-gray-200 p-6 mb-6 shadow-sm">
+        <h2 className="text-[17px] font-semibold text-gray-800 mb-4">Post a fresh update</h2>
+        <form onSubmit={submitNewPost} className="space-y-4">
+          {error && (
+            <div className="text-[13px] text-red-700 bg-red-50 border border-red-100 rounded-lg px-3 py-2">
+              {error}
+            </div>
+          )}
+          <div>
+            <label className="block text-[13px] font-medium text-gray-600 mb-1.5">
+              Item name *
+            </label>
+            <input
+              value={itemName}
+              onChange={(e) => setItemName(e.target.value)}
+              className="w-full px-3.5 py-2.5 rounded-md border-[1.5px] border-gray-200 text-[15px] text-gray-800 bg-white outline-none focus:border-green-400 transition-colors"
+              placeholder="e.g. Bok Choy, Lamb Shoulder"
+              required
+            />
+          </div>
+          <div>
+            <label className="block text-[13px] font-medium text-gray-600 mb-1.5">
+              Note (optional)
+            </label>
+            <input
+              value={note}
+              onChange={(e) => setNote(e.target.value)}
+              className="w-full px-3.5 py-2.5 rounded-md border-[1.5px] border-gray-200 text-[15px] text-gray-800 bg-white outline-none focus:border-green-400 transition-colors"
+              placeholder="e.g. Just arrived from local farm - very limited"
+            />
+          </div>
+          <button
+            type="submit"
+            disabled={submitting}
+            className="px-5 py-2.5 rounded-md text-sm font-semibold text-white bg-green-600 hover:bg-green-800 transition-colors disabled:opacity-50"
+          >
+            {submitting ? "Posting..." : "Post update"}
+          </button>
+        </form>
+      </div>
+
+      <h2 className="text-[17px] font-semibold text-gray-800 mb-4">Your posts</h2>
+
+      {loading ? (
+        <p className="text-[14px] text-gray-400">Loading posts...</p>
+      ) : loadError ? (
+        <p className="text-[14px] text-red-700 bg-red-50 border border-red-100 rounded-lg px-3 py-2">
+          {loadError}
+        </p>
+      ) : posts.length === 0 ? (
+        <p className="text-[14px] text-gray-400">No posts yet. Share what is fresh today.</p>
+      ) : (
+        <div className="space-y-2">
+          {posts.map((post) => {
+            const isEditing = editingPostId === post.id;
+
+            return (
+              <div
+                key={post.id}
+                className="p-3.5 bg-white border border-gray-200 rounded-xl shadow-sm"
+              >
+                {isEditing ? (
+                  <div className="space-y-3">
+                    <div>
+                      <label className="block text-[12px] font-medium text-gray-600 mb-1">
+                        Item name
+                      </label>
+                      <input
+                        value={editDraft.itemName}
+                        onChange={(e) =>
+                          setEditDraft((prev) => ({
+                            ...prev,
+                            itemName: e.target.value,
+                          }))
+                        }
+                        className="w-full px-3 py-2 rounded-md border border-gray-200 text-[14px] outline-none focus:border-green-400"
+                      />
+                    </div>
+                    <div>
+                      <label className="block text-[12px] font-medium text-gray-600 mb-1">
+                        Note
+                      </label>
+                      <input
+                        value={editDraft.note}
+                        onChange={(e) =>
+                          setEditDraft((prev) => ({
+                            ...prev,
+                            note: e.target.value,
+                          }))
+                        }
+                        className="w-full px-3 py-2 rounded-md border border-gray-200 text-[14px] outline-none focus:border-green-400"
+                        placeholder="Optional note for shoppers"
+                      />
+                    </div>
+                    <div className="flex gap-1.5 justify-end">
+                      <button
+                        type="button"
+                        onClick={cancelEdit}
+                        className="px-3 py-1 rounded-md text-[12px] font-medium border border-gray-200 hover:bg-gray-100 transition-colors text-gray-600"
+                      >
+                        Cancel
+                      </button>
+                      <button
+                        type="button"
+                        onClick={() => saveEdit(post.id)}
+                        disabled={savingEdit}
+                        className="px-3 py-1 rounded-md text-[12px] font-medium border border-green-200 bg-green-50 text-green-700 hover:bg-green-100 transition-colors disabled:opacity-50"
+                      >
+                        {savingEdit ? "Saving..." : "Save"}
+                      </button>
+                    </div>
+                  </div>
+                ) : (
+                  <div className="flex items-center gap-3">
+                    <div className="text-2xl w-11 h-11 rounded-md bg-gray-50 flex items-center justify-center shrink-0">
+                      🌿
+                    </div>
+                    <div className="flex-1 min-w-0">
+                      <div className="font-medium text-[15px] truncate">{post.itemName}</div>
+                      <div className="text-[12px] text-gray-400 mt-0.5">
+                        {post.note ? `${post.note} · ` : ""}
+                        posted {relativeTime(post.createdAt)}
+                      </div>
+                    </div>
+                    <div className="flex gap-1.5 shrink-0">
+                      <button
+                        type="button"
+                        onClick={() => beginEdit(post)}
+                        className="px-3 py-1 rounded-md text-[12px] font-medium border border-gray-200 hover:bg-gray-100 transition-colors text-gray-600"
+                      >
+                        Edit
+                      </button>
+                      <button
+                        type="button"
+                        onClick={() => deletePost(post.id)}
+                        className="px-3 py-1 rounded-md text-[12px] font-medium border border-gray-200 hover:bg-red-50 hover:text-red-800 hover:border-red-200 transition-colors text-gray-600"
+                      >
+                        Delete
+                      </button>
+                    </div>
+                  </div>
+                )}
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </>
+  );
+}

--- a/app/(dashboard)/dashboard/posts/page.tsx
+++ b/app/(dashboard)/dashboard/posts/page.tsx
@@ -1,6 +1,27 @@
-// TODO: Story 11 (Fresh Today — Owner), Story 10 (Edit or Delete a Post)
+import { auth } from "@/auth";
+import { redirect } from "next/navigation";
+import ManagePostsClient from "./ManagePostsClient";
 
-export default function ManagePostsPage() {
+export default async function ManagePostsPage() {
+  const session = await auth();
+  if (!session?.user?.id) redirect("/login");
+
+  if (!session.storeId) {
+    return (
+      <div className="max-w-[700px]">
+        <p className="text-[11px] font-semibold uppercase tracking-wider text-gray-400 mb-2">
+          Owner portal
+        </p>
+        <h1 className="font-display text-[28px] font-medium text-gray-800 tracking-tight">
+          Fresh updates
+        </h1>
+        <p className="text-[15px] text-gray-600 mt-4">
+          Complete your store profile first, then you can post updates.
+        </p>
+      </div>
+    );
+  }
+
   return (
     <div className="max-w-[700px]">
       <div className="mb-7">
@@ -14,66 +35,7 @@ export default function ManagePostsPage() {
           Let shoppers know what just arrived or is back in stock.
         </p>
       </div>
-
-      {/* New post form */}
-      <div className="bg-white rounded-2xl border border-gray-200 p-6 mb-6 shadow-sm">
-        <h2 className="text-[17px] font-semibold text-gray-800 mb-4">
-          Post a fresh update
-        </h2>
-        <div className="mb-4">
-          <label className="block text-[13px] font-medium text-gray-600 mb-1.5">
-            Item name *
-          </label>
-          <input
-            className="w-full px-3.5 py-2.5 rounded-md border-[1.5px] border-gray-200 text-[15px] text-gray-800 bg-white outline-none focus:border-green-400 transition-colors"
-            placeholder="e.g. Bok Choy, Lamb Shoulder"
-          />
-        </div>
-        <div className="mb-4">
-          <label className="block text-[13px] font-medium text-gray-600 mb-1.5">
-            Note (optional)
-          </label>
-          <input
-            className="w-full px-3.5 py-2.5 rounded-md border-[1.5px] border-gray-200 text-[15px] text-gray-800 bg-white outline-none focus:border-green-400 transition-colors"
-            placeholder="e.g. Just arrived from local farm — very limited"
-          />
-        </div>
-        <button className="px-5 py-2.5 rounded-md text-sm font-semibold text-white bg-green-600 hover:bg-green-800 transition-colors">
-          Post update
-        </button>
-      </div>
-
-      {/* Existing posts */}
-      <h2 className="text-[17px] font-semibold text-gray-800 mb-4">
-        Your posts
-      </h2>
-
-      {/* Placeholder post rows */}
-      {[
-        { icon: "🥬", title: "Bok Choy — Fresh today", meta: "Fresh Today · posted 1h ago" },
-        { icon: "🥩", title: "Lamb Shoulder — Halal certified", meta: "Fresh Today · posted 2h ago" },
-      ].map((post, i) => (
-        <div
-          key={i}
-          className="flex items-center gap-3 p-3.5 bg-white border border-gray-200 rounded-xl mb-2 hover:border-gray-400 transition-colors shadow-sm"
-        >
-          <div className="text-2xl w-11 h-11 rounded-md bg-gray-50 flex items-center justify-center shrink-0">
-            {post.icon}
-          </div>
-          <div className="flex-1 min-w-0">
-            <div className="font-medium text-[15px] truncate">{post.title}</div>
-            <div className="text-[12px] text-gray-400 mt-0.5">{post.meta}</div>
-          </div>
-          <div className="flex gap-1.5 shrink-0">
-            <button className="px-3 py-1 rounded-md text-[12px] font-medium border border-gray-200 hover:bg-gray-100 transition-colors text-gray-600">
-              Edit
-            </button>
-            <button className="px-3 py-1 rounded-md text-[12px] font-medium border border-gray-200 hover:bg-red-50 hover:text-red-800 hover:border-red-200 transition-colors text-gray-600">
-              Delete
-            </button>
-          </div>
-        </div>
-      ))}
+      <ManagePostsClient storeId={session.storeId} />
     </div>
   );
 }

--- a/app/(public)/stores/[id]/page.tsx
+++ b/app/(public)/stores/[id]/page.tsx
@@ -7,19 +7,7 @@ import { prisma } from "@/lib/prisma";
 import { notFound } from "next/navigation";
 import Link from "next/link";
 import ItemAvailabilitySearch from "@/components/ItemAvailabilitySearch";
-
-function timeAgo(date: Date): string {
-  const ms = Date.now() - new Date(date).getTime();
-  const hours = Math.floor(ms / 3_600_000);
-  if (hours < 1) return "posted just now";
-  if (hours < 24) return `posted ${hours}h ago`;
-  const days = Math.floor(hours / 24);
-  return `${days}d ago`;
-}
-
-function isStale(date: Date): boolean {
-  return Date.now() - new Date(date).getTime() > 48 * 3_600_000;
-}
+import FreshTodaySection from "@/components/FreshTodaySection";
 
 export default async function StoreProfilePage({
   params,
@@ -31,11 +19,6 @@ export default async function StoreProfilePage({
   const store = await prisma.store.findUnique({
     where: { id },
     include: {
-      freshUpdates: {
-        where: { deletedAt: null },
-        orderBy: { createdAt: "desc" },
-        take: 10,
-      },
       deals: {
         where: {
           deletedAt: null,
@@ -63,7 +46,7 @@ export default async function StoreProfilePage({
       </div>
 
       {/* Profile hero */}
-      <div className="bg-gradient-to-br from-green-50 to-white rounded-3xl border border-gray-200 p-8 flex flex-col sm:flex-row items-start gap-6 mb-6">
+      <div className="bg-linear-to-br from-green-50 to-white rounded-3xl border border-gray-200 p-8 flex flex-col sm:flex-row items-start gap-6 mb-6">
         <div className="text-[56px] w-20 h-20 rounded-2xl bg-green-50 flex items-center justify-center shrink-0 border-2 border-green-100">
           🏪
         </div>
@@ -103,53 +86,7 @@ export default async function StoreProfilePage({
         storeAddress={store.address}
       />
 
-      {/* Fresh Today — Story 1 */}
-      <div className="bg-white rounded-2xl border border-gray-200 p-6 mb-4">
-        <h2 className="text-[17px] font-semibold text-gray-800 mb-4 flex items-center gap-2">
-          🌿 Fresh Today
-        </h2>
-        {store.freshUpdates.length === 0 ? (
-          <div className="text-center py-8">
-            <div className="text-[42px] mb-3">🫙</div>
-            <h3 className="text-[16px] font-semibold text-gray-800 mb-1">
-              No recent updates
-            </h3>
-            <p className="text-[14px] text-gray-400">
-              This store hasn&apos;t posted any inventory updates in the last 7
-              days.
-            </p>
-          </div>
-        ) : (
-          store.freshUpdates.map((update) => (
-            <div
-              key={update.id}
-              className={`flex justify-between items-start py-3 border-b border-gray-100 last:border-b-0 ${
-                isStale(update.createdAt) ? "opacity-40" : ""
-              }`}
-            >
-              <div>
-                <div className="font-medium text-[15px]">
-                  {update.itemName}
-                </div>
-                {update.note && (
-                  <div className="text-[13px] text-gray-400 mt-0.5">
-                    {update.note}
-                  </div>
-                )}
-              </div>
-              <span
-                className={`text-[12px] px-2 py-0.5 rounded-full whitespace-nowrap ml-2 shrink-0 ${
-                  isStale(update.createdAt)
-                    ? "bg-gray-100 text-gray-400"
-                    : "bg-green-50 text-green-600"
-                }`}
-              >
-                {timeAgo(update.createdAt)}
-              </span>
-            </div>
-          ))
-        )}
-      </div>
+      <FreshTodaySection storeId={store.id} />
 
       {/* Deals This Week — Story 2 */}
       <div className="bg-white rounded-2xl border border-gray-200 p-6">

--- a/app/api/stores/[id]/deals/[dealId]/route.ts
+++ b/app/api/stores/[id]/deals/[dealId]/route.ts
@@ -1,9 +1,129 @@
 import { NextRequest, NextResponse } from "next/server";
+import { Prisma } from "@/app/generated/prisma/client";
 import { prisma } from "@/lib/prisma";
 import { requireStoreOwnerForStore } from "@/lib/require-store-owner";
 
 interface RouteContext {
   params: Promise<{ id: string; dealId: string }>;
+}
+
+function dealJson(deal: {
+  id: string;
+  title: string;
+  description: string | null;
+  price: Prisma.Decimal | null;
+  discountPct: number | null;
+  expiresAt: Date;
+  isExpired: boolean;
+  createdAt: Date;
+  sourceDealId: string | null;
+}) {
+  return {
+    ...deal,
+    price: deal.price != null ? deal.price.toString() : null,
+    expiresAt: deal.expiresAt.toISOString(),
+    createdAt: deal.createdAt.toISOString(),
+  };
+}
+
+function parsePrice(raw: unknown): { ok: true; value: Prisma.Decimal } | { ok: false; error: string } {
+  if (raw === undefined || raw === null || raw === "") {
+    return { ok: false, error: "price is required" };
+  }
+  const n =
+    typeof raw === "number"
+      ? raw
+      : typeof raw === "string"
+        ? parseFloat(raw)
+        : NaN;
+  if (!Number.isFinite(n)) {
+    return { ok: false, error: "price must be a valid number" };
+  }
+  if (n <= 0) {
+    return { ok: false, error: "price must be greater than zero" };
+  }
+  return { ok: true, value: new Prisma.Decimal(n.toFixed(2)) };
+}
+
+/** Edit deal fields (owner only). */
+export async function PATCH(request: NextRequest, context: RouteContext) {
+  const { id: storeId, dealId } = await context.params;
+
+  const gate = await requireStoreOwnerForStore(storeId);
+  if ("response" in gate) return gate.response;
+
+  const body = await request.json().catch(() => null);
+  if (!body || typeof body !== "object") {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  const existing = await prisma.deal.findFirst({
+    where: { id: dealId, storeId, deletedAt: null },
+    select: { id: true },
+  });
+  if (!existing) {
+    return NextResponse.json({ error: "Deal not found" }, { status: 404 });
+  }
+
+  const patch: Prisma.DealUpdateInput = {};
+  const now = new Date();
+
+  if (body.price !== undefined) {
+    const price = parsePrice(body.price);
+    if (!price.ok) {
+      return NextResponse.json({ error: price.error }, { status: 400 });
+    }
+    patch.price = price.value;
+  }
+
+  if (body.description !== undefined) {
+    if (typeof body.description !== "string") {
+      return NextResponse.json({ error: "description must be a string" }, { status: 400 });
+    }
+    patch.description = body.description.trim() || null;
+  }
+
+  if (body.title !== undefined) {
+    if (typeof body.title !== "string" || !body.title.trim()) {
+      return NextResponse.json({ error: "title must be a non-empty string" }, { status: 400 });
+    }
+    patch.title = body.title.trim();
+  }
+
+  if (body.expires_at !== undefined) {
+    const expiresAt = new Date(body.expires_at as string);
+    if (Number.isNaN(expiresAt.getTime())) {
+      return NextResponse.json({ error: "expires_at must be a valid date" }, { status: 400 });
+    }
+    if (expiresAt <= now) {
+      return NextResponse.json({ error: "expires_at must be in the future" }, { status: 400 });
+    }
+    patch.expiresAt = expiresAt;
+    patch.isExpired = false;
+    patch.expiryNotifiedAt = null;
+  }
+
+  if (Object.keys(patch).length === 0) {
+    return NextResponse.json({ error: "No fields provided for update" }, { status: 400 });
+  }
+
+  const updated = await prisma.deal.update({
+    where: { id: dealId },
+    data: patch,
+    select: {
+      id: true,
+      title: true,
+      description: true,
+      price: true,
+      discountPct: true,
+      expiresAt: true,
+      isExpired: true,
+      createdAt: true,
+      sourceDealId: true,
+    },
+  });
+
+  return NextResponse.json({ deal: dealJson(updated) });
 }
 
 /** Soft-delete a deal before natural expiry (owner only). */

--- a/app/api/stores/[id]/posts/[postId]/route.ts
+++ b/app/api/stores/[id]/posts/[postId]/route.ts
@@ -1,0 +1,100 @@
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { requireStoreOwnerForStore } from "@/lib/require-store-owner";
+import { publishPostEvent } from "@/lib/post-events";
+
+interface RouteContext {
+  params: Promise<{ id: string; postId: string }>;
+}
+
+function postJson(post: {
+  id: string;
+  itemName: string;
+  note: string | null;
+  createdAt: Date;
+}) {
+  return {
+    id: post.id,
+    itemName: post.itemName,
+    note: post.note,
+    createdAt: post.createdAt.toISOString(),
+  };
+}
+
+export async function PATCH(request: NextRequest, context: RouteContext) {
+  const { id: storeId, postId } = await context.params;
+  const gate = await requireStoreOwnerForStore(storeId);
+  if ("response" in gate) return gate.response;
+
+  const body = await request.json().catch(() => null);
+  if (!body || typeof body !== "object") {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  const post = await prisma.freshUpdate.findFirst({
+    where: { id: postId, storeId, deletedAt: null },
+    select: { id: true },
+  });
+  if (!post) {
+    return NextResponse.json({ error: "Post not found" }, { status: 404 });
+  }
+
+  const patch: { itemName?: string; note?: string | null } = {};
+
+  if (body.item_name !== undefined) {
+    if (typeof body.item_name !== "string" || !body.item_name.trim()) {
+      return NextResponse.json({ error: "item_name must be a non-empty string" }, { status: 400 });
+    }
+    patch.itemName = body.item_name.trim();
+  }
+
+  if (body.note !== undefined) {
+    if (body.note === null) {
+      patch.note = null;
+    } else if (typeof body.note === "string") {
+      patch.note = body.note.trim() || null;
+    } else {
+      return NextResponse.json({ error: "note must be a string or null" }, { status: 400 });
+    }
+  }
+
+  if (Object.keys(patch).length === 0) {
+    return NextResponse.json({ error: "No fields provided for update" }, { status: 400 });
+  }
+
+  const updated = await prisma.freshUpdate.update({
+    where: { id: postId },
+    data: patch,
+    select: {
+      id: true,
+      itemName: true,
+      note: true,
+      createdAt: true,
+    },
+  });
+
+  publishPostEvent({ type: "POST_UPDATE", storeId, postId });
+  return NextResponse.json({ post: postJson(updated) });
+}
+
+export async function DELETE(_request: NextRequest, context: RouteContext) {
+  const { id: storeId, postId } = await context.params;
+  const gate = await requireStoreOwnerForStore(storeId);
+  if ("response" in gate) return gate.response;
+
+  const post = await prisma.freshUpdate.findFirst({
+    where: { id: postId, storeId, deletedAt: null },
+    select: { id: true },
+  });
+  if (!post) {
+    return NextResponse.json({ error: "Post not found" }, { status: 404 });
+  }
+
+  await prisma.freshUpdate.update({
+    where: { id: postId },
+    data: { deletedAt: new Date() },
+  });
+
+  publishPostEvent({ type: "POST_DELETE", storeId, postId });
+  return NextResponse.json({ ok: true });
+}

--- a/app/api/stores/[id]/posts/events/route.ts
+++ b/app/api/stores/[id]/posts/events/route.ts
@@ -1,0 +1,49 @@
+import { NextRequest, NextResponse } from "next/server";
+import { subscribeToPostEvents } from "@/lib/post-events";
+
+interface RouteContext {
+  params: Promise<{ id: string }>;
+}
+
+export const dynamic = "force-dynamic";
+
+function sseHeaders() {
+  return {
+    "Content-Type": "text/event-stream",
+    "Cache-Control": "no-cache, no-transform",
+    Connection: "keep-alive",
+  };
+}
+
+export async function GET(_request: NextRequest, context: RouteContext) {
+  const { id: storeId } = await context.params;
+  const encoder = new TextEncoder();
+  let unsubscribe: (() => void) | undefined;
+  let keepAlive: ReturnType<typeof setInterval> | undefined;
+
+  const stream = new ReadableStream({
+    start(controller) {
+      const write = (chunk: string) => {
+        controller.enqueue(encoder.encode(chunk));
+      };
+
+      write("retry: 3000\n\n");
+
+      unsubscribe = subscribeToPostEvents((event) => {
+        if (event.storeId !== storeId) return;
+        write(`event: ${event.type}\n`);
+        write(`data: ${JSON.stringify(event)}\n\n`);
+      });
+
+      keepAlive = setInterval(() => {
+        write(": keep-alive\n\n");
+      }, 25_000);
+    },
+    cancel() {
+      if (keepAlive) clearInterval(keepAlive);
+      if (unsubscribe) unsubscribe();
+    },
+  });
+
+  return new NextResponse(stream, { headers: sseHeaders() });
+}

--- a/app/api/stores/[id]/posts/route.ts
+++ b/app/api/stores/[id]/posts/route.ts
@@ -1,0 +1,80 @@
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { requireStoreOwnerForStore } from "@/lib/require-store-owner";
+import { publishPostEvent } from "@/lib/post-events";
+
+interface RouteContext {
+  params: Promise<{ id: string }>;
+}
+
+function postJson(post: {
+  id: string;
+  itemName: string;
+  note: string | null;
+  createdAt: Date;
+}) {
+  return {
+    id: post.id,
+    itemName: post.itemName,
+    note: post.note,
+    createdAt: post.createdAt.toISOString(),
+  };
+}
+
+export async function GET(_request: NextRequest, context: RouteContext) {
+  const { id: storeId } = await context.params;
+  const gate = await requireStoreOwnerForStore(storeId);
+  if ("response" in gate) return gate.response;
+
+  const posts = await prisma.freshUpdate.findMany({
+    where: { storeId, deletedAt: null },
+    orderBy: { createdAt: "desc" },
+    select: {
+      id: true,
+      itemName: true,
+      note: true,
+      createdAt: true,
+    },
+  });
+
+  return NextResponse.json({ posts: posts.map(postJson) });
+}
+
+export async function POST(request: NextRequest, context: RouteContext) {
+  const { id: storeId } = await context.params;
+  const gate = await requireStoreOwnerForStore(storeId);
+  if ("response" in gate) return gate.response;
+
+  const body = await request.json().catch(() => null);
+  if (!body || typeof body !== "object") {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  if (typeof body.item_name !== "string" || !body.item_name.trim()) {
+    return NextResponse.json({ error: "item_name is required" }, { status: 400 });
+  }
+
+  const itemName = body.item_name.trim();
+  const note =
+    typeof body.note === "string" ? body.note.trim() || null : body.note == null ? null : undefined;
+  if (note === undefined) {
+    return NextResponse.json({ error: "note must be a string when provided" }, { status: 400 });
+  }
+
+  const post = await prisma.freshUpdate.create({
+    data: {
+      storeId,
+      itemName,
+      note,
+    },
+    select: {
+      id: true,
+      itemName: true,
+      note: true,
+      createdAt: true,
+    },
+  });
+
+  publishPostEvent({ type: "POST_UPDATE", storeId, postId: post.id });
+  return NextResponse.json({ post: postJson(post) }, { status: 201 });
+}

--- a/app/api/stores/[id]/updates/route.ts
+++ b/app/api/stores/[id]/updates/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { requireStoreOwnerForStore } from "@/lib/require-store-owner";
+import { publishPostEvent } from "@/lib/post-events";
 
 interface RouteContext {
   params: Promise<{ id: string }>;
@@ -70,5 +71,6 @@ export async function POST(
     },
   });
 
+  publishPostEvent({ type: "POST_UPDATE", storeId, postId: update.id });
   return NextResponse.json({ update }, { status: 201 });
 }

--- a/components/FreshTodaySection.tsx
+++ b/components/FreshTodaySection.tsx
@@ -22,22 +22,43 @@ export default function FreshTodaySection({ storeId }: Props) {
 
   useEffect(() => {
     let cancelled = false;
+    const load = async () => {
+      const res = await fetch(`/api/stores/${storeId}/updates`);
+      if (!res.ok) throw new Error("Failed to fetch");
+      const data = await res.json();
+      if (cancelled) return;
+      setUpdates(data.updates ?? []);
+      setError(false);
+    };
 
-    async function load() {
+    (async () => {
       try {
-        const res = await fetch(`/api/stores/${storeId}/updates`);
-        if (!res.ok) throw new Error("Failed to fetch");
-        const data = await res.json();
-        if (!cancelled) setUpdates(data.updates ?? []);
+        await load();
       } catch {
         if (!cancelled) setError(true);
       } finally {
         if (!cancelled) setLoading(false);
       }
-    }
+    })();
 
-    load();
-    return () => { cancelled = true; };
+    const source = new EventSource(`/api/stores/${storeId}/posts/events`);
+    const refresh = () => {
+      void load().catch(() => {
+        if (!cancelled) setError(true);
+      });
+    };
+    source.addEventListener("POST_UPDATE", refresh);
+    source.addEventListener("POST_DELETE", refresh);
+    source.onerror = () => {
+      source.close();
+    };
+
+    return () => {
+      cancelled = true;
+      source.removeEventListener("POST_UPDATE", refresh);
+      source.removeEventListener("POST_DELETE", refresh);
+      source.close();
+    };
   }, [storeId]);
 
   if (loading) return <FreshTodaySkeleton />;

--- a/lib/post-events.ts
+++ b/lib/post-events.ts
@@ -1,0 +1,44 @@
+type PostEventType = "POST_UPDATE" | "POST_DELETE";
+
+export interface PostEventPayload {
+  type: PostEventType;
+  storeId: string;
+  postId: string;
+  occurredAt: string;
+}
+
+type PostEventListener = (event: PostEventPayload) => void;
+
+interface PostEventHub {
+  listeners: Set<PostEventListener>;
+}
+
+declare global {
+  var __postEventHub: PostEventHub | undefined;
+}
+
+function hub(): PostEventHub {
+  if (!globalThis.__postEventHub) {
+    globalThis.__postEventHub = { listeners: new Set<PostEventListener>() };
+  }
+  return globalThis.__postEventHub;
+}
+
+export function subscribeToPostEvents(listener: PostEventListener): () => void {
+  const current = hub();
+  current.listeners.add(listener);
+  return () => {
+    current.listeners.delete(listener);
+  };
+}
+
+export function publishPostEvent(event: Omit<PostEventPayload, "occurredAt">): void {
+  const payload: PostEventPayload = {
+    ...event,
+    occurredAt: new Date().toISOString(),
+  };
+  const current = hub();
+  for (const listener of current.listeners) {
+    listener(payload);
+  }
+}


### PR DESCRIPTION
## Summary

This PR implements owner-side editing workflows for both Fresh Today posts and deals, while keeping shopper-facing content in sync without a page reload.

- Add owner post management APIs under `/api/stores/:id/posts`:
  - `GET /posts` (owner-only list)
  - `POST /posts` (create)
  - `PATCH /posts/:postId` (edit)
  - `DELETE /posts/:postId` (soft-delete via `deletedAt`)
- Enforce ownership checks on all post edit/delete operations using existing store-owner auth guard.
- Add real-time post event broadcasting (`POST_UPDATE`, `POST_DELETE`) and an events stream endpoint at `/api/stores/:id/posts/events`.
- Replace placeholder Owner `Manage Posts` page with a functional client:
  - create post form
  - inline edit + save
  - delete with confirmation
- Update shopper Fresh Today UI to subscribe to post events and refresh automatically.
- Add owner deal edit capability:
  - `PATCH /api/stores/:id/deals/:dealId` with validation for `price`, `description`, `title`, and `expires_at`
  - inline edit/save UI in Manage Deals (active + inactive deal rows)

## Why

Store owners need to quickly correct or remove inaccurate content (e.g., sold-out items or pricing mistakes) to maintain shopper trust. This change gives owners direct control over posted content and propagates updates to shoppers immediately.

## Test Plan

- [x] Run `npm run lint`
- [x] As owner, open Manage Posts and verify each post shows Edit/Delete actions
- [x] Edit a post and confirm the updated content appears in shopper Fresh Today without reload
- [x] Delete a post, confirm delete prompt appears, and verify post disappears from shopper Fresh Today
- [x] As owner, edit a deal (price/description/title/expiry) and confirm Save persists changes
- [x] Verify unauthorized users cannot edit/delete posts or deals for another store
- [x] Verify deleted posts are soft-deleted (`deletedAt` set) and hidden from shopper feed