### PR TITLE
feat: add fresh updates functionality and enhance store profile page

### DIFF
--- a/app/(dashboard)/dashboard/posts/ManageFreshUpdatesClient.tsx
+++ b/app/(dashboard)/dashboard/posts/ManageFreshUpdatesClient.tsx
@@ -1,7 +1,8 @@
 "use client";
 
 import Link from "next/link";
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { MAX_ITEM_NAME_LEN, MAX_NOTE_LEN } from "@/lib/fresh-updates";
 import { relativeTime } from "@/lib/time";
 
 type ApiFreshUpdate = {
@@ -22,36 +23,63 @@ export default function ManageFreshUpdatesClient({ storeId }: { storeId: string 
   const [success, setSuccess] = useState<string | null>(null);
   const [submitting, setSubmitting] = useState(false);
 
-  const load = useCallback(async () => {
-    setLoadError(null);
-    const res = await fetch(`/api/stores/${storeId}/updates?all=true`);
-    if (!res.ok) {
-      let msg = "Could not load updates. Refresh the page or sign in again.";
-      try {
-        const data = (await res.json()) as { error?: string };
-        if (typeof data.error === "string" && data.error) msg = data.error;
-      } catch {
-        /* ignore */
-      }
-      setLoadError(msg);
-      setUpdates([]);
-      return;
-    }
-    const data = (await res.json()) as { updates?: ApiFreshUpdate[] };
-    setUpdates(data.updates ?? []);
-  }, [storeId]);
+  const mountedRef = useRef(true);
+  const submitAbortRef = useRef<AbortController | null>(null);
 
   useEffect(() => {
-    let cancelled = false;
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+      submitAbortRef.current?.abort();
+    };
+  }, []);
+
+  const load = useCallback(
+    async (signal?: AbortSignal) => {
+      if (!mountedRef.current) return;
+      setLoadError(null);
+      try {
+        const res = await fetch(`/api/stores/${storeId}/updates?all=true`, {
+          signal,
+        });
+        if (signal?.aborted) return;
+        if (!mountedRef.current) return;
+        if (!res.ok) {
+          let msg = "Could not load updates. Refresh the page or sign in again.";
+          try {
+            const data = (await res.json()) as { error?: string };
+            if (typeof data.error === "string" && data.error) msg = data.error;
+          } catch {
+            /* ignore */
+          }
+          setLoadError(msg);
+          setUpdates([]);
+          return;
+        }
+        const data = (await res.json()) as { updates?: ApiFreshUpdate[] };
+        if (!mountedRef.current) return;
+        setUpdates(data.updates ?? []);
+      } catch (e) {
+        if (e instanceof DOMException && e.name === "AbortError") return;
+        if (!mountedRef.current) return;
+        setLoadError("Could not load updates. Refresh the page or sign in again.");
+        setUpdates([]);
+      }
+    },
+    [storeId],
+  );
+
+  useEffect(() => {
+    const ac = new AbortController();
     (async () => {
       try {
-        await load();
+        await load(ac.signal);
       } finally {
-        if (!cancelled) setLoading(false);
+        if (mountedRef.current && !ac.signal.aborted) setLoading(false);
       }
     })();
     return () => {
-      cancelled = true;
+      ac.abort();
     };
   }, [load]);
 
@@ -64,6 +92,9 @@ export default function ManageFreshUpdatesClient({ storeId }: { storeId: string 
       setError("Item name is required.");
       return;
     }
+    submitAbortRef.current?.abort();
+    const ac = new AbortController();
+    submitAbortRef.current = ac;
     setSubmitting(true);
     try {
       const res = await fetch(`/api/stores/${storeId}/updates`, {
@@ -73,8 +104,11 @@ export default function ManageFreshUpdatesClient({ storeId }: { storeId: string 
           item_name: name,
           note: note.trim() || undefined,
         }),
+        signal: ac.signal,
       });
+      if (ac.signal.aborted || !mountedRef.current) return;
       const data = await res.json().catch(() => ({}));
+      if (ac.signal.aborted || !mountedRef.current) return;
       if (!res.ok) {
         setError(
           typeof data.error === "string" ? data.error : "Could not post update.",
@@ -84,9 +118,13 @@ export default function ManageFreshUpdatesClient({ storeId }: { storeId: string 
       setItemName("");
       setNote("");
       setSuccess("Posted. Shoppers will see it on your store page right away.");
-      await load();
+      await load(ac.signal);
+    } catch (e) {
+      if (e instanceof DOMException && e.name === "AbortError") return;
+      if (!mountedRef.current) return;
+      setError("Could not post update.");
     } finally {
-      setSubmitting(false);
+      if (mountedRef.current && !ac.signal.aborted) setSubmitting(false);
     }
   }
 
@@ -127,6 +165,7 @@ export default function ManageFreshUpdatesClient({ storeId }: { storeId: string 
             <input
               id="fresh-item-name"
               value={itemName}
+              maxLength={MAX_ITEM_NAME_LEN}
               onChange={(e) => setItemName(e.target.value)}
               className="w-full px-3.5 py-2.5 rounded-md border-[1.5px] border-gray-200 text-[15px] text-gray-800 bg-white outline-none focus:border-green-400 transition-colors"
               placeholder="e.g. Bok Choy, Lamb Shoulder"
@@ -140,11 +179,13 @@ export default function ManageFreshUpdatesClient({ storeId }: { storeId: string 
             >
               Note (optional)
             </label>
-            <input
+            <textarea
               id="fresh-note"
               value={note}
+              maxLength={MAX_NOTE_LEN}
+              rows={2}
               onChange={(e) => setNote(e.target.value)}
-              className="w-full px-3.5 py-2.5 rounded-md border-[1.5px] border-gray-200 text-[15px] text-gray-800 bg-white outline-none focus:border-green-400 transition-colors"
+              className="w-full px-3.5 py-2.5 rounded-md border-[1.5px] border-gray-200 text-[15px] text-gray-800 bg-white outline-none focus:border-green-400 transition-colors resize-y min-h-[80px]"
               placeholder="e.g. Just arrived from local farm — very limited"
               autoComplete="off"
             />

--- a/app/(dashboard)/dashboard/posts/ManageFreshUpdatesClient.tsx
+++ b/app/(dashboard)/dashboard/posts/ManageFreshUpdatesClient.tsx
@@ -1,0 +1,230 @@
+"use client";
+
+import Link from "next/link";
+import { useCallback, useEffect, useState } from "react";
+import { relativeTime } from "@/lib/time";
+
+type ApiFreshUpdate = {
+  id: string;
+  itemName: string;
+  note: string | null;
+  createdAt: string;
+  isStale: boolean;
+};
+
+export default function ManageFreshUpdatesClient({ storeId }: { storeId: string }) {
+  const [updates, setUpdates] = useState<ApiFreshUpdate[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const [itemName, setItemName] = useState("");
+  const [note, setNote] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [success, setSuccess] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+
+  const load = useCallback(async () => {
+    setLoadError(null);
+    const res = await fetch(`/api/stores/${storeId}/updates?all=true`);
+    if (!res.ok) {
+      let msg = "Could not load updates. Refresh the page or sign in again.";
+      try {
+        const data = (await res.json()) as { error?: string };
+        if (typeof data.error === "string" && data.error) msg = data.error;
+      } catch {
+        /* ignore */
+      }
+      setLoadError(msg);
+      setUpdates([]);
+      return;
+    }
+    const data = (await res.json()) as { updates?: ApiFreshUpdate[] };
+    setUpdates(data.updates ?? []);
+  }, [storeId]);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        await load();
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [load]);
+
+  async function onSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setError(null);
+    setSuccess(null);
+    const name = itemName.trim();
+    if (!name) {
+      setError("Item name is required.");
+      return;
+    }
+    setSubmitting(true);
+    try {
+      const res = await fetch(`/api/stores/${storeId}/updates`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          item_name: name,
+          note: note.trim() || undefined,
+        }),
+      });
+      const data = await res.json().catch(() => ({}));
+      if (!res.ok) {
+        setError(
+          typeof data.error === "string" ? data.error : "Could not post update.",
+        );
+        return;
+      }
+      setItemName("");
+      setNote("");
+      setSuccess("Posted. Shoppers will see it on your store page right away.");
+      await load();
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <>
+      <div className="bg-white rounded-2xl border border-gray-200 p-6 mb-6 shadow-sm">
+        <h2 className="text-[17px] font-semibold text-gray-800 mb-1">
+          Post a fresh update
+        </h2>
+        <p className="text-[13px] text-gray-500 mb-4">
+          Shoppers see these under Fresh Today on{" "}
+          <Link
+            href={`/stores/${storeId}`}
+            className="text-green-600 font-medium hover:text-green-800"
+          >
+            your store page
+          </Link>
+          .
+        </p>
+        <form onSubmit={onSubmit} className="space-y-4">
+          {error && (
+            <div className="text-[13px] text-red-700 bg-red-50 border border-red-100 rounded-lg px-3 py-2">
+              {error}
+            </div>
+          )}
+          {success && (
+            <div className="text-[13px] text-green-800 bg-green-50 border border-green-100 rounded-lg px-3 py-2">
+              {success}
+            </div>
+          )}
+          <div>
+            <label
+              htmlFor="fresh-item-name"
+              className="block text-[13px] font-medium text-gray-600 mb-1.5"
+            >
+              Item name *
+            </label>
+            <input
+              id="fresh-item-name"
+              value={itemName}
+              onChange={(e) => setItemName(e.target.value)}
+              className="w-full px-3.5 py-2.5 rounded-md border-[1.5px] border-gray-200 text-[15px] text-gray-800 bg-white outline-none focus:border-green-400 transition-colors"
+              placeholder="e.g. Bok Choy, Lamb Shoulder"
+              autoComplete="off"
+            />
+          </div>
+          <div>
+            <label
+              htmlFor="fresh-note"
+              className="block text-[13px] font-medium text-gray-600 mb-1.5"
+            >
+              Note (optional)
+            </label>
+            <input
+              id="fresh-note"
+              value={note}
+              onChange={(e) => setNote(e.target.value)}
+              className="w-full px-3.5 py-2.5 rounded-md border-[1.5px] border-gray-200 text-[15px] text-gray-800 bg-white outline-none focus:border-green-400 transition-colors"
+              placeholder="e.g. Just arrived from local farm — very limited"
+              autoComplete="off"
+            />
+          </div>
+          <button
+            type="submit"
+            disabled={submitting}
+            className="px-5 py-2.5 rounded-md text-sm font-semibold text-white bg-green-600 hover:bg-green-800 transition-colors disabled:opacity-60 disabled:pointer-events-none"
+          >
+            {submitting ? "Posting…" : "Post update"}
+          </button>
+        </form>
+      </div>
+
+      <h2 className="text-[17px] font-semibold text-gray-800 mb-4">
+        Your recent updates
+      </h2>
+      <p className="text-[13px] text-gray-500 mb-3">
+        Newest first. Updates older than about two days show as faded — same as
+        shoppers see.
+      </p>
+
+      {loading ? (
+        <div className="space-y-2">
+          {[1, 2, 3].map((i) => (
+            <div
+              key={i}
+              className="h-[72px] rounded-xl border border-gray-100 bg-gray-50 animate-pulse"
+            />
+          ))}
+        </div>
+      ) : loadError ? (
+        <p className="text-[14px] text-red-700">{loadError}</p>
+      ) : updates.length === 0 ? (
+        <p className="text-[14px] text-gray-500 py-6">
+          No updates yet. Post what just came in so nearby shoppers know to stop
+          by.
+        </p>
+      ) : (
+        <ul className="space-y-2">
+          {updates.map((u) => {
+            const stale = u.isStale;
+            const when = relativeTime(u.createdAt);
+            return (
+              <li
+                key={u.id}
+                className={`flex flex-col sm:flex-row sm:items-start sm:justify-between gap-2 p-3.5 bg-white border border-gray-200 rounded-xl shadow-sm ${
+                  stale ? "opacity-50" : ""
+                }`}
+              >
+                <div className="min-w-0">
+                  <div
+                    className={`font-medium text-gray-800 truncate ${
+                      stale ? "text-[14px]" : "text-[15px]"
+                    }`}
+                  >
+                    {u.itemName}
+                  </div>
+                  {u.note && (
+                    <div className="text-[13px] text-gray-500 mt-0.5 line-clamp-2">
+                      {u.note}
+                    </div>
+                  )}
+                </div>
+                <div className="flex items-center gap-2 shrink-0">
+                  <span
+                    className={`text-[12px] px-2 py-0.5 rounded-full whitespace-nowrap ${
+                      stale
+                        ? "bg-gray-100 text-gray-500"
+                        : "bg-green-50 text-green-600"
+                    }`}
+                  >
+                    {when ?? "—"}
+                  </span>
+                </div>
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </>
+  );
+}

--- a/app/(dashboard)/dashboard/posts/page.tsx
+++ b/app/(dashboard)/dashboard/posts/page.tsx
@@ -1,6 +1,28 @@
-// TODO: Story 11 (Fresh Today — Owner), Story 10 (Edit or Delete a Post)
+import { auth } from "@/auth";
+import { redirect } from "next/navigation";
+import ManageFreshUpdatesClient from "./ManageFreshUpdatesClient";
 
-export default function ManagePostsPage() {
+export default async function ManagePostsPage() {
+  const session = await auth();
+  if (!session?.user?.id) redirect("/login");
+
+  if (!session.storeId) {
+    return (
+      <div className="max-w-[700px]">
+        <p className="text-[11px] font-semibold uppercase tracking-wider text-gray-400 mb-2">
+          Owner portal
+        </p>
+        <h1 className="font-display text-[28px] font-medium text-gray-800 tracking-tight">
+          Fresh updates
+        </h1>
+        <p className="text-[15px] text-gray-600 mt-4">
+          Complete your store profile first, then you can post fresh-today
+          updates.
+        </p>
+      </div>
+    );
+  }
+
   return (
     <div className="max-w-[700px]">
       <div className="mb-7">
@@ -15,65 +37,7 @@ export default function ManagePostsPage() {
         </p>
       </div>
 
-      {/* New post form */}
-      <div className="bg-white rounded-2xl border border-gray-200 p-6 mb-6 shadow-sm">
-        <h2 className="text-[17px] font-semibold text-gray-800 mb-4">
-          Post a fresh update
-        </h2>
-        <div className="mb-4">
-          <label className="block text-[13px] font-medium text-gray-600 mb-1.5">
-            Item name *
-          </label>
-          <input
-            className="w-full px-3.5 py-2.5 rounded-md border-[1.5px] border-gray-200 text-[15px] text-gray-800 bg-white outline-none focus:border-green-400 transition-colors"
-            placeholder="e.g. Bok Choy, Lamb Shoulder"
-          />
-        </div>
-        <div className="mb-4">
-          <label className="block text-[13px] font-medium text-gray-600 mb-1.5">
-            Note (optional)
-          </label>
-          <input
-            className="w-full px-3.5 py-2.5 rounded-md border-[1.5px] border-gray-200 text-[15px] text-gray-800 bg-white outline-none focus:border-green-400 transition-colors"
-            placeholder="e.g. Just arrived from local farm — very limited"
-          />
-        </div>
-        <button className="px-5 py-2.5 rounded-md text-sm font-semibold text-white bg-green-600 hover:bg-green-800 transition-colors">
-          Post update
-        </button>
-      </div>
-
-      {/* Existing posts */}
-      <h2 className="text-[17px] font-semibold text-gray-800 mb-4">
-        Your posts
-      </h2>
-
-      {/* Placeholder post rows */}
-      {[
-        { icon: "🥬", title: "Bok Choy — Fresh today", meta: "Fresh Today · posted 1h ago" },
-        { icon: "🥩", title: "Lamb Shoulder — Halal certified", meta: "Fresh Today · posted 2h ago" },
-      ].map((post, i) => (
-        <div
-          key={i}
-          className="flex items-center gap-3 p-3.5 bg-white border border-gray-200 rounded-xl mb-2 hover:border-gray-400 transition-colors shadow-sm"
-        >
-          <div className="text-2xl w-11 h-11 rounded-md bg-gray-50 flex items-center justify-center shrink-0">
-            {post.icon}
-          </div>
-          <div className="flex-1 min-w-0">
-            <div className="font-medium text-[15px] truncate">{post.title}</div>
-            <div className="text-[12px] text-gray-400 mt-0.5">{post.meta}</div>
-          </div>
-          <div className="flex gap-1.5 shrink-0">
-            <button className="px-3 py-1 rounded-md text-[12px] font-medium border border-gray-200 hover:bg-gray-100 transition-colors text-gray-600">
-              Edit
-            </button>
-            <button className="px-3 py-1 rounded-md text-[12px] font-medium border border-gray-200 hover:bg-red-50 hover:text-red-800 hover:border-red-200 transition-colors text-gray-600">
-              Delete
-            </button>
-          </div>
-        </div>
-      ))}
+      <ManageFreshUpdatesClient storeId={session.storeId} />
     </div>
   );
 }

--- a/app/(public)/stores/[id]/page.tsx
+++ b/app/(public)/stores/[id]/page.tsx
@@ -3,26 +3,18 @@
 // Story 12: No auth required
 
 import DealCard from "@/components/DealCard";
-import { FRESH_UPDATE_PUBLIC_WINDOW_MS } from "@/lib/fresh-updates";
+import {
+  enrichFreshUpdatesWithStale,
+  FRESH_UPDATE_PUBLIC_LIST_LIMIT,
+  FRESH_UPDATE_PUBLIC_WINDOW_MS,
+} from "@/lib/fresh-updates";
 import { prisma } from "@/lib/prisma";
+import { relativeTime } from "@/lib/time";
 import { notFound } from "next/navigation";
 import Link from "next/link";
 import ItemAvailabilitySearch from "@/components/ItemAvailabilitySearch";
 
 export const dynamic = "force-dynamic";
-
-function timeAgo(date: Date): string {
-  const ms = Date.now() - new Date(date).getTime();
-  const hours = Math.floor(ms / 3_600_000);
-  if (hours < 1) return "posted just now";
-  if (hours < 24) return `posted ${hours}h ago`;
-  const days = Math.floor(hours / 24);
-  return `${days}d ago`;
-}
-
-function isStale(date: Date): boolean {
-  return Date.now() - new Date(date).getTime() > 48 * 3_600_000;
-}
 
 export default async function StoreProfilePage({
   params,
@@ -43,7 +35,7 @@ export default async function StoreProfilePage({
           createdAt: { gte: freshSince },
         },
         orderBy: { createdAt: "desc" },
-        take: 10,
+        take: FRESH_UPDATE_PUBLIC_LIST_LIMIT,
       },
       deals: {
         where: {
@@ -57,6 +49,11 @@ export default async function StoreProfilePage({
   });
 
   if (!store || !store.isPublished) notFound();
+
+  const freshUpdatesDisplay = enrichFreshUpdatesWithStale(
+    store.freshUpdates,
+    asOf,
+  );
 
   const hours = store.hours as { open?: string; close?: string } | null;
 
@@ -117,7 +114,7 @@ export default async function StoreProfilePage({
         <h2 className="text-[17px] font-semibold text-gray-800 mb-4 flex items-center gap-2">
           🌿 Fresh Today
         </h2>
-        {store.freshUpdates.length === 0 ? (
+        {freshUpdatesDisplay.length === 0 ? (
           <div className="text-center py-8">
             <div className="text-[42px] mb-3">🫙</div>
             <h3 className="text-[16px] font-semibold text-gray-800 mb-1">
@@ -129,11 +126,11 @@ export default async function StoreProfilePage({
             </p>
           </div>
         ) : (
-          store.freshUpdates.map((update) => (
+          freshUpdatesDisplay.map((update) => (
             <div
               key={update.id}
               className={`flex justify-between items-start py-3 border-b border-gray-100 last:border-b-0 ${
-                isStale(update.createdAt) ? "opacity-40" : ""
+                update.isStale ? "opacity-40" : ""
               }`}
             >
               <div>
@@ -148,12 +145,12 @@ export default async function StoreProfilePage({
               </div>
               <span
                 className={`text-[12px] px-2 py-0.5 rounded-full whitespace-nowrap ml-2 shrink-0 ${
-                  isStale(update.createdAt)
+                  update.isStale
                     ? "bg-gray-100 text-gray-400"
                     : "bg-green-50 text-green-600"
                 }`}
               >
-                {timeAgo(update.createdAt)}
+                {relativeTime(update.createdAt) ?? "—"}
               </span>
             </div>
           ))

--- a/app/(public)/stores/[id]/page.tsx
+++ b/app/(public)/stores/[id]/page.tsx
@@ -3,10 +3,13 @@
 // Story 12: No auth required
 
 import DealCard from "@/components/DealCard";
+import { FRESH_UPDATE_PUBLIC_WINDOW_MS } from "@/lib/fresh-updates";
 import { prisma } from "@/lib/prisma";
 import { notFound } from "next/navigation";
 import Link from "next/link";
 import ItemAvailabilitySearch from "@/components/ItemAvailabilitySearch";
+
+export const dynamic = "force-dynamic";
 
 function timeAgo(date: Date): string {
   const ms = Date.now() - new Date(date).getTime();
@@ -27,12 +30,18 @@ export default async function StoreProfilePage({
   params: Promise<{ id: string }>;
 }) {
   const { id } = await params;
+  // Request-time cutoff for the 7-day Fresh Today window (not React client render).
+  const asOf = new Date();
+  const freshSince = new Date(asOf.getTime() - FRESH_UPDATE_PUBLIC_WINDOW_MS);
 
   const store = await prisma.store.findUnique({
     where: { id },
     include: {
       freshUpdates: {
-        where: { deletedAt: null },
+        where: {
+          deletedAt: null,
+          createdAt: { gte: freshSince },
+        },
         orderBy: { createdAt: "desc" },
         take: 10,
       },

--- a/app/api/stores/[id]/updates/route.ts
+++ b/app/api/stores/[id]/updates/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import {
   enrichFreshUpdatesWithStale,
+  FRESH_UPDATE_PUBLIC_LIST_LIMIT,
   FRESH_UPDATE_PUBLIC_WINDOW_MS,
   parseFreshUpdatePostBody,
 } from "@/lib/fresh-updates";
@@ -34,6 +35,7 @@ export async function GET(request: NextRequest, context: RouteContext) {
       ...(windowStart ? { createdAt: { gte: windowStart } } : {}),
     },
     orderBy: { createdAt: "desc" },
+    ...(showAll ? {} : { take: FRESH_UPDATE_PUBLIC_LIST_LIMIT }),
     select: {
       id: true,
       itemName: true,
@@ -61,11 +63,6 @@ export async function POST(
   const parsed = parseFreshUpdatePostBody(body);
   if (!parsed.ok) {
     return NextResponse.json({ error: parsed.error }, { status: 400 });
-  }
-
-  const store = await prisma.store.findUnique({ where: { id: storeId } });
-  if (!store) {
-    return NextResponse.json({ error: "Store not found" }, { status: 404 });
   }
 
   const update = await prisma.freshUpdate.create({

--- a/app/api/stores/[id]/updates/route.ts
+++ b/app/api/stores/[id]/updates/route.ts
@@ -1,4 +1,9 @@
 import { NextRequest, NextResponse } from "next/server";
+import {
+  enrichFreshUpdatesWithStale,
+  FRESH_UPDATE_PUBLIC_WINDOW_MS,
+  parseFreshUpdatePostBody,
+} from "@/lib/fresh-updates";
 import { prisma } from "@/lib/prisma";
 import { requireStoreOwnerForStore } from "@/lib/require-store-owner";
 
@@ -7,20 +12,26 @@ interface RouteContext {
 }
 
 // Story 1: GET /api/stores/:id/updates — List fresh updates (newest first, 48h staleness)
-export async function GET(
-  _request: NextRequest,
-  context: RouteContext,
-) {
+// Story 11: GET ?all=true — All non-deleted updates (owner only)
+export async function GET(request: NextRequest, context: RouteContext) {
   const { id: storeId } = await context.params;
+  const showAll = request.nextUrl.searchParams.get("all") === "true";
+  const now = new Date();
 
-  const SEVEN_DAYS_AGO = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000);
-  const FORTY_EIGHT_HOURS_AGO = new Date(Date.now() - 48 * 60 * 60 * 1000);
+  if (showAll) {
+    const gate = await requireStoreOwnerForStore(storeId);
+    if ("response" in gate) return gate.response;
+  }
+
+  const windowStart = showAll
+    ? null
+    : new Date(now.getTime() - FRESH_UPDATE_PUBLIC_WINDOW_MS);
 
   const updates = await prisma.freshUpdate.findMany({
     where: {
       storeId,
       deletedAt: null,
-      createdAt: { gte: SEVEN_DAYS_AGO },
+      ...(windowStart ? { createdAt: { gte: windowStart } } : {}),
     },
     orderBy: { createdAt: "desc" },
     select: {
@@ -31,10 +42,7 @@ export async function GET(
     },
   });
 
-  const enriched = updates.map((u) => ({
-    ...u,
-    isStale: u.createdAt < FORTY_EIGHT_HOURS_AGO,
-  }));
+  const enriched = enrichFreshUpdatesWithStale(updates, now);
 
   return NextResponse.json({ updates: enriched });
 }
@@ -50,11 +58,9 @@ export async function POST(
   if ("response" in gate) return gate.response;
 
   const body = await request.json().catch(() => null);
-  if (!body || !body.item_name || typeof body.item_name !== "string") {
-    return NextResponse.json(
-      { error: "item_name is required" },
-      { status: 400 },
-    );
+  const parsed = parseFreshUpdatePostBody(body);
+  if (!parsed.ok) {
+    return NextResponse.json({ error: parsed.error }, { status: 400 });
   }
 
   const store = await prisma.store.findUnique({ where: { id: storeId } });
@@ -65,8 +71,8 @@ export async function POST(
   const update = await prisma.freshUpdate.create({
     data: {
       storeId,
-      itemName: body.item_name,
-      note: body.note ?? null,
+      itemName: parsed.itemName,
+      note: parsed.note,
     },
   });
 

--- a/lib/fresh-updates.test.ts
+++ b/lib/fresh-updates.test.ts
@@ -3,6 +3,7 @@ import { describe, it } from "node:test";
 import {
   enrichFreshUpdatesWithStale,
   FRESH_UPDATE_STALE_THRESHOLD_MS,
+  MAX_ITEM_NAME_LEN,
   parseFreshUpdatePostBody,
 } from "./fresh-updates";
 
@@ -64,9 +65,11 @@ describe("parseFreshUpdatePostBody", () => {
   });
 
   it("rejects oversized item_name", () => {
-    const r = parseFreshUpdatePostBody({ item_name: "x".repeat(201) });
+    const r = parseFreshUpdatePostBody({
+      item_name: "x".repeat(MAX_ITEM_NAME_LEN + 1),
+    });
     assert.equal(r.ok, false);
-    if (!r.ok) assert.match(r.error, /200/i);
+    if (!r.ok) assert.match(r.error, new RegExp(String(MAX_ITEM_NAME_LEN)));
   });
 });
 

--- a/lib/fresh-updates.test.ts
+++ b/lib/fresh-updates.test.ts
@@ -1,0 +1,107 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+  enrichFreshUpdatesWithStale,
+  FRESH_UPDATE_STALE_THRESHOLD_MS,
+  parseFreshUpdatePostBody,
+} from "./fresh-updates";
+
+describe("parseFreshUpdatePostBody", () => {
+  it("accepts item_name only", () => {
+    const r = parseFreshUpdatePostBody({ item_name: "  Bok Choy  " });
+    assert.equal(r.ok, true);
+    if (r.ok) {
+      assert.equal(r.itemName, "Bok Choy");
+      assert.equal(r.note, null);
+    }
+  });
+
+  it("accepts optional note", () => {
+    const r = parseFreshUpdatePostBody({
+      item_name: "Lamb",
+      note: "  Halal cut  ",
+    });
+    assert.equal(r.ok, true);
+    if (r.ok) {
+      assert.equal(r.itemName, "Lamb");
+      assert.equal(r.note, "Halal cut");
+    }
+  });
+
+  it("treats blank note as null", () => {
+    const r = parseFreshUpdatePostBody({ item_name: "Spinach", note: "   " });
+    assert.equal(r.ok, true);
+    if (r.ok) assert.equal(r.note, null);
+  });
+
+  it("rejects missing item_name", () => {
+    const r = parseFreshUpdatePostBody({ note: "x" });
+    assert.equal(r.ok, false);
+    if (!r.ok) assert.match(r.error, /item_name is required/i);
+  });
+
+  it("rejects empty trimmed item_name", () => {
+    const r = parseFreshUpdatePostBody({ item_name: "  \t  " });
+    assert.equal(r.ok, false);
+    if (!r.ok) assert.match(r.error, /cannot be empty/i);
+  });
+
+  it("rejects non-object body", () => {
+    assert.equal(parseFreshUpdatePostBody(null).ok, false);
+    assert.equal(parseFreshUpdatePostBody("x").ok, false);
+  });
+
+  it("rejects wrong types", () => {
+    const r = parseFreshUpdatePostBody({ item_name: 12 });
+    assert.equal(r.ok, false);
+    if (!r.ok) assert.match(r.error, /string/i);
+  });
+
+  it("rejects non-string note", () => {
+    const r = parseFreshUpdatePostBody({ item_name: "Ok", note: 99 });
+    assert.equal(r.ok, false);
+    if (!r.ok) assert.match(r.error, /note/i);
+  });
+
+  it("rejects oversized item_name", () => {
+    const r = parseFreshUpdatePostBody({ item_name: "x".repeat(201) });
+    assert.equal(r.ok, false);
+    if (!r.ok) assert.match(r.error, /200/i);
+  });
+});
+
+describe("enrichFreshUpdatesWithStale", () => {
+  const t0 = new Date("2026-01-01T12:00:00.000Z");
+
+  it("marks rows older than threshold as stale", () => {
+    const freshAt = new Date(
+      t0.getTime() - (FRESH_UPDATE_STALE_THRESHOLD_MS - 60_000),
+    );
+    const staleAt = new Date(
+      t0.getTime() - (FRESH_UPDATE_STALE_THRESHOLD_MS + 60_000),
+    );
+    const rows = [
+      { id: "a", createdAt: freshAt },
+      { id: "b", createdAt: staleAt },
+    ];
+    const out = enrichFreshUpdatesWithStale(rows, t0);
+    assert.equal(out[0].isStale, false);
+    assert.equal(out[1].isStale, true);
+  });
+
+  it("preserves reverse-chronological order of input", () => {
+    const newer = new Date("2026-01-01T11:00:00.000Z");
+    const older = new Date("2026-01-01T10:00:00.000Z");
+    const out = enrichFreshUpdatesWithStale(
+      [
+        { id: "new", createdAt: newer },
+        { id: "old", createdAt: older },
+      ],
+      t0,
+    );
+    assert.deepEqual(
+      out.map((u) => u.id),
+      ["new", "old"],
+    );
+  });
+});

--- a/lib/fresh-updates.ts
+++ b/lib/fresh-updates.ts
@@ -1,0 +1,70 @@
+const HOUR_MS = 60 * 60 * 1000;
+
+/** Public list only includes updates from the last 7 days. */
+export const FRESH_UPDATE_PUBLIC_WINDOW_MS = 7 * 24 * HOUR_MS;
+
+/** Updates older than this are flagged as stale in API and UI. */
+export const FRESH_UPDATE_STALE_THRESHOLD_MS = 48 * HOUR_MS;
+
+const MAX_ITEM_NAME_LEN = 200;
+const MAX_NOTE_LEN = 500;
+
+export type ParsedFreshUpdatePost =
+  | { ok: true; itemName: string; note: string | null }
+  | { ok: false; error: string };
+
+/**
+ * Validates JSON body for POST /api/stores/:id/updates.
+ */
+export function parseFreshUpdatePostBody(body: unknown): ParsedFreshUpdatePost {
+  if (body === null || typeof body !== "object") {
+    return { ok: false, error: "Request body must be a JSON object." };
+  }
+  const o = body as Record<string, unknown>;
+  const rawName = o.item_name;
+  if (rawName === undefined || rawName === null) {
+    return { ok: false, error: "item_name is required." };
+  }
+  if (typeof rawName !== "string") {
+    return { ok: false, error: "item_name must be a string." };
+  }
+  const itemName = rawName.trim();
+  if (!itemName) {
+    return { ok: false, error: "item_name cannot be empty." };
+  }
+  if (itemName.length > MAX_ITEM_NAME_LEN) {
+    return {
+      ok: false,
+      error: `item_name must be at most ${MAX_ITEM_NAME_LEN} characters.`,
+    };
+  }
+
+  let note: string | null = null;
+  if (o.note !== undefined && o.note !== null) {
+    if (typeof o.note !== "string") {
+      return { ok: false, error: "note must be a string when provided." };
+    }
+    const t = o.note.trim();
+    if (t.length > MAX_NOTE_LEN) {
+      return {
+        ok: false,
+        error: `note must be at most ${MAX_NOTE_LEN} characters.`,
+      };
+    }
+    note = t.length > 0 ? t : null;
+  }
+
+  return { ok: true, itemName, note };
+}
+
+export function enrichFreshUpdatesWithStale<T extends { createdAt: Date }>(
+  rows: T[],
+  now: Date,
+  staleThresholdMs: number = FRESH_UPDATE_STALE_THRESHOLD_MS,
+): (T & { isStale: boolean })[] {
+  const nowMs = now.getTime();
+  return rows.map((u) => ({
+    ...u,
+    isStale: nowMs - u.createdAt.getTime() > staleThresholdMs,
+  }));
+}

--- a/lib/fresh-updates.ts
+++ b/lib/fresh-updates.ts
@@ -6,8 +6,14 @@ export const FRESH_UPDATE_PUBLIC_WINDOW_MS = 7 * 24 * HOUR_MS;
 /** Updates older than this are flagged as stale in API and UI. */
 export const FRESH_UPDATE_STALE_THRESHOLD_MS = 48 * HOUR_MS;
 
-const MAX_ITEM_NAME_LEN = 200;
-const MAX_NOTE_LEN = 500;
+/**
+ * Max rows returned for public Fresh Today (store page + public GET updates).
+ * Owner `?all=true` lists are uncapped.
+ */
+export const FRESH_UPDATE_PUBLIC_LIST_LIMIT = 10;
+
+export const MAX_ITEM_NAME_LEN = 200;
+export const MAX_NOTE_LEN = 500;
 
 export type ParsedFreshUpdatePost =
   | { ok: true; itemName: string; note: string | null }

--- a/package.json
+++ b/package.json
@@ -14,7 +14,9 @@
     "test:deals-machine": "tsx scripts/deals-machine-tests.ts",
     "test:deals-smoke": "tsx scripts/smoke-deals.ts",
     "test:geocode": "tsx scripts/geocode-branch-tests.ts",
-    "test:store-profile": "tsx scripts/store-profile-machine-tests.ts"
+    "test:store-profile": "tsx scripts/store-profile-machine-tests.ts",
+    "test:fresh-updates": "node --import tsx --test lib/fresh-updates.test.ts",
+    "test:fresh-updates-machine": "tsx scripts/fresh-updates-machine-tests.ts"
   },
   "dependencies": {
     "@prisma/adapter-pg": "^7.5.0",

--- a/scripts/fresh-updates-machine-tests.ts
+++ b/scripts/fresh-updates-machine-tests.ts
@@ -3,6 +3,7 @@ import { randomUUID } from "node:crypto";
 import { strict as assert } from "node:assert";
 import { PrismaPg } from "@prisma/adapter-pg";
 import { PrismaClient } from "../app/generated/prisma/client";
+import { FRESH_UPDATE_PUBLIC_LIST_LIMIT } from "../lib/fresh-updates";
 import { fixtureMeta, ids } from "../prisma/fixtures";
 
 const BASE = process.env.TEST_BASE_URL ?? "http://localhost:3000";
@@ -145,6 +146,10 @@ async function main() {
     assert.equal(res.status, 200);
     const updates = (json as { updates: UpdateRow[] }).updates;
     assert.ok(Array.isArray(updates), "updates array");
+    assert.ok(
+      updates.length <= FRESH_UPDATE_PUBLIC_LIST_LIMIT,
+      "public GET should cap rows to match store page",
+    );
     const idx = updates.findIndex((u) => u.id === createdId);
     assert.ok(idx >= 0, "new update should appear in public list");
     if (idx > 0) {
@@ -241,11 +246,5 @@ main()
         where: { id: { in: testRowIds } },
       });
     }
-    await prisma.freshUpdate.deleteMany({
-      where: {
-        storeId: ids.stores.lotus,
-        itemName: { in: ["__machine_stale_probe__", "__machine_ancient__"] },
-      },
-    });
     await prisma.$disconnect();
   });

--- a/scripts/fresh-updates-machine-tests.ts
+++ b/scripts/fresh-updates-machine-tests.ts
@@ -1,0 +1,251 @@
+import "dotenv/config";
+import { randomUUID } from "node:crypto";
+import { strict as assert } from "node:assert";
+import { PrismaPg } from "@prisma/adapter-pg";
+import { PrismaClient } from "../app/generated/prisma/client";
+import { fixtureMeta, ids } from "../prisma/fixtures";
+
+const BASE = process.env.TEST_BASE_URL ?? "http://localhost:3000";
+const OWNER_PASSWORD = fixtureMeta.ownerPlaintextPassword;
+const LOTUS_OWNER = "linh@lotus-market.test";
+const CRESCENT_OWNER = "abdullah@crescent-halal.test";
+
+const prisma = new PrismaClient({
+  adapter: new PrismaPg({ connectionString: process.env.DATABASE_URL! }),
+});
+
+const testRowIds: string[] = [];
+
+function cookiePairHeader(setCookieLines: string[]): string {
+  return setCookieLines
+    .map((line) => line.split(";")[0]?.trim())
+    .filter(Boolean)
+    .join("; ");
+}
+
+async function postJson(path: string, body: unknown, cookieHeader?: string) {
+  const headers: Record<string, string> = { "Content-Type": "application/json" };
+  if (cookieHeader) headers.Cookie = cookieHeader;
+  const res = await fetch(`${BASE}${path}`, {
+    method: "POST",
+    headers,
+    body: JSON.stringify(body),
+  });
+  const text = await res.text();
+  let json: unknown = null;
+  try {
+    json = text ? (JSON.parse(text) as unknown) : null;
+  } catch {
+    json = text;
+  }
+  return { res, json, setCookies: res.headers.getSetCookie?.() ?? [] };
+}
+
+async function getJson(path: string, cookieHeader?: string) {
+  const headers: Record<string, string> = {};
+  if (cookieHeader) headers.Cookie = cookieHeader;
+  const res = await fetch(`${BASE}${path}`, { headers });
+  const text = await res.text();
+  let json: unknown = null;
+  try {
+    json = text ? (JSON.parse(text) as unknown) : null;
+  } catch {
+    json = text;
+  }
+  return { res, json };
+}
+
+async function login(email: string) {
+  const { res, setCookies } = await postJson("/auth/login", {
+    email,
+    password: OWNER_PASSWORD,
+    callbackUrl: "/dashboard",
+  });
+  assert.equal(res.status, 200, `login should succeed for ${email}`);
+  return cookiePairHeader(setCookies);
+}
+
+type UpdateRow = {
+  id: string;
+  itemName: string;
+  note: string | null;
+  createdAt: string;
+  isStale: boolean;
+};
+
+async function main() {
+  console.log(`Testing fresh updates (Story 11) against ${BASE}\n`);
+
+  const lotusId = ids.stores.lotus;
+
+  // POST without session
+  {
+    const { res } = await postJson(`/api/stores/${lotusId}/updates`, {
+      item_name: "X",
+    });
+    assert.equal(res.status, 401, "POST without auth should be 401");
+  }
+
+  const lotusCookie = await login(LOTUS_OWNER);
+  const crescentCookie = await login(CRESCENT_OWNER);
+
+  // wrong owner
+  {
+    const { res } = await postJson(
+      `/api/stores/${lotusId}/updates`,
+      { item_name: "Intruder item" },
+      crescentCookie,
+    );
+    assert.equal(res.status, 403, "non-owner POST should be 403");
+  }
+
+  // invalid body
+  for (const body of [null, {}, { item_name: "" }, { item_name: "  " }]) {
+    const { res, json } = await postJson(
+      `/api/stores/${lotusId}/updates`,
+      body,
+      lotusCookie,
+    );
+    assert.equal(res.status, 400, `invalid body should be 400: ${JSON.stringify(body)}`);
+    const err = (json as { error?: string }).error;
+    assert.ok(typeof err === "string" && err.length > 0, "error message should be present");
+  }
+
+  const uniqueName = `Machine Test Melon ${randomUUID().slice(0, 8)}`;
+  const uniqueNote = "Integration note";
+
+  // successful create
+  let createdId = "";
+  {
+    const { res, json } = await postJson(
+      `/api/stores/${lotusId}/updates`,
+      { item_name: uniqueName, note: uniqueNote },
+      lotusCookie,
+    );
+    assert.equal(res.status, 201, "valid POST should be 201");
+    const update = (json as { update?: { id: string; storeId: string; itemName: string; note: string | null; createdAt: string } })
+      .update;
+    assert.ok(update?.id, "response should include update id");
+    assert.equal(update?.storeId, lotusId, "update should belong to store");
+    assert.equal(update?.itemName, uniqueName, "item name should match");
+    assert.equal(update?.note, uniqueNote, "note should match");
+    assert.ok(update?.createdAt, "createdAt should be set");
+    createdId = update!.id;
+    testRowIds.push(createdId);
+
+    const row = await prisma.freshUpdate.findUnique({ where: { id: createdId } });
+    assert.ok(row, "row should exist in DB");
+    assert.equal(row!.storeId, lotusId);
+    assert.equal(row!.itemName, uniqueName);
+  }
+
+  // public GET: newest first and includes our row
+  {
+    const { res, json } = await getJson(`/api/stores/${lotusId}/updates`);
+    assert.equal(res.status, 200);
+    const updates = (json as { updates: UpdateRow[] }).updates;
+    assert.ok(Array.isArray(updates), "updates array");
+    const idx = updates.findIndex((u) => u.id === createdId);
+    assert.ok(idx >= 0, "new update should appear in public list");
+    if (idx > 0) {
+      const newer = new Date(updates[idx - 1]!.createdAt).getTime();
+      const ours = new Date(updates[idx]!.createdAt).getTime();
+      assert.ok(
+        newer >= ours,
+        "list should be reverse chronological (newer before older)",
+      );
+    }
+  }
+
+  // stale flag: row 3 days old, still inside 7d public window
+  const staleTestId = randomUUID();
+  testRowIds.push(staleTestId);
+  const threeDaysAgo = new Date(Date.now() - 3 * 24 * 60 * 60 * 1000);
+  await prisma.freshUpdate.create({
+    data: {
+      id: staleTestId,
+      storeId: lotusId,
+      itemName: "__machine_stale_probe__",
+      note: null,
+      createdAt: threeDaysAgo,
+    },
+  });
+
+  {
+    const { res, json } = await getJson(`/api/stores/${lotusId}/updates`);
+    assert.equal(res.status, 200);
+    const updates = (json as { updates: UpdateRow[] }).updates;
+    const row = updates.find((u) => u.id === staleTestId);
+    assert.ok(row, "synthetic stale row should be in public window");
+    assert.equal(row!.isStale, true, "3d-old update should be flagged stale");
+  }
+
+  // older than 7d: hidden from public, visible with ?all=true
+  const ancientId = randomUUID();
+  testRowIds.push(ancientId);
+  const tenDaysAgo = new Date(Date.now() - 10 * 24 * 60 * 60 * 1000);
+  await prisma.freshUpdate.create({
+    data: {
+      id: ancientId,
+      storeId: lotusId,
+      itemName: "__machine_ancient__",
+      note: null,
+      createdAt: tenDaysAgo,
+    },
+  });
+
+  {
+    const { res, json } = await getJson(`/api/stores/${lotusId}/updates`);
+    assert.equal(res.status, 200);
+    const updates = (json as { updates: UpdateRow[] }).updates;
+    assert.ok(
+      !updates.some((u) => u.id === ancientId),
+      "10d-old update should not appear in public list",
+    );
+  }
+
+  {
+    const { res } = await getJson(`/api/stores/${lotusId}/updates?all=true`);
+    assert.equal(res.status, 401, "all=true without auth should be 401");
+  }
+
+  {
+    const { res, json } = await getJson(
+      `/api/stores/${lotusId}/updates?all=true`,
+      lotusCookie,
+    );
+    assert.equal(res.status, 200);
+    const updates = (json as { updates: UpdateRow[] }).updates;
+    assert.ok(
+      updates.some((u) => u.id === ancientId),
+      "owner all=true should include ancient update",
+    );
+    for (let i = 1; i < updates.length; i++) {
+      const a = new Date(updates[i - 1]!.createdAt).getTime();
+      const b = new Date(updates[i]!.createdAt).getTime();
+      assert.ok(a >= b, "owner list should stay newest-first");
+    }
+  }
+
+  console.log("All fresh-updates machine tests passed.");
+}
+
+main()
+  .catch((err) => {
+    console.error(err);
+    process.exitCode = 1;
+  })
+  .finally(async () => {
+    if (testRowIds.length > 0) {
+      await prisma.freshUpdate.deleteMany({
+        where: { id: { in: testRowIds } },
+      });
+    }
+    await prisma.freshUpdate.deleteMany({
+      where: {
+        storeId: ids.stores.lotus,
+        itemName: { in: ["__machine_stale_probe__", "__machine_ancient__"] },
+      },
+    });
+    await prisma.$disconnect();
+  });


### PR DESCRIPTION
## Summary

**Closes #13 :** Fresh Today updates (owner) — store owners can post quick “fresh today” / “newly in stock” updates so shoppers see what is available on the public store page.

- **`POST /api/stores/:id/updates`** (owner-only) accepts **`item_name`** (required, trimmed) and optional **`note`**; validates with shared **`parseFreshUpdatePostBody`**; persists a **`FreshUpdate`** with **`createdAt`** and **`storeId`**; returns **`201`** with **`{ update }`**. Invalid input returns **`400`** with a clear **`{ error }`** string (missing/empty name, bad types, length limits). Wrong owner → **`403`**; no session → **`401`**.
- **`GET /api/stores/:id/updates`** returns updates **newest first**, each with **`isStale: true`** when older than **48 hours** (de-emphasis signal). Public callers only see the **last 7 days**; **`?all=true`** (authenticated owner of that store only) returns **all** non-deleted updates for the dashboard list.
- **Shared module** **`lib/fresh-updates.ts`** centralizes the 7-day window constant, stale enrichment, and POST body parsing for deterministic tests and consistent API behavior.
- **UI:** **`/dashboard/posts`** — minimal form (item name + optional note), success feedback, link to the public **`/stores/:id`** page, and a **“Your recent updates”** list (newest first, stale rows visually faded). Redirects unsigned-in users to **`/login`**; owners without a store see copy pointing them to complete profile (same pattern as deals).
- **Shopper page:** **`/stores/[id]`** loads Fresh Today rows in the **same 7-day window** as the public updates API and sets **`dynamic = "force-dynamic"`** so new posts show up on refresh without aggressive caching.
- **Tests:** **`lib/fresh-updates.test.ts`** + **`npm run test:fresh-updates`** (Node test runner); **`scripts/fresh-updates-machine-tests.ts`** + **`npm run test:fresh-updates-machine`** (HTTP + DB, needs running app). **`package.json`** documents both scripts.

---

## Acceptance Criteria

**Human**

- [x] Owner can post an update in under ~30 seconds using a short form (item name required, note optional).
- [x] After submit, the update shows on the public store page’s Fresh Today section within seconds (dynamic store page + DB write).
- [x] Recent updates appear first; older ones are clearly de-emphasized (stale styling + **`isStale`** in API).
- [x] Bad submissions show clear errors and are not saved.

**Machine**

- [x] Owners can create an update with item name and optional note; row is tied to the correct store and has a timestamp.
- [x] **`GET /api/stores/:id/updates`** returns updates in **reverse chronological order** and flags **`isStale`** for items older than the 48h threshold.
- [x] Invalid **`POST`** bodies return **400** with a clear **`error`** message and do not create rows.
- [x] **`npm run test:fresh-updates`** passes (unit tests for validation + stale enrichment).
- [x] **`npm run test:fresh-updates-machine`** passes against a running app with **`DATABASE_URL`** configured (auth, 403/401, ordering, 7d vs **`all=true`**, stale flag).

---

## Files Changed

| Area | Files |
|------|--------|
| **Owner UI** | `app/(dashboard)/dashboard/posts/page.tsx`, `app/(dashboard)/dashboard/posts/ManageFreshUpdatesClient.tsx` |
| **Updates API** | `app/api/stores/[id]/updates/route.ts` |
| **Shared logic** | `lib/fresh-updates.ts` |
| **Unit tests** | `lib/fresh-updates.test.ts` |
| **Machine tests** | `scripts/fresh-updates-machine-tests.ts` |
| **Shopper page** | `app/(public)/stores/[id]/page.tsx` |
| **Config** | `package.json` (`test:fresh-updates`, `test:fresh-updates-machine`) |
