### PR TITLE
feat: added button to reuse old coupon with new expiration date

### DIFF
--- a/app/(dashboard)/dashboard/deals/ManageDealsClient.tsx
+++ b/app/(dashboard)/dashboard/deals/ManageDealsClient.tsx
@@ -90,7 +90,7 @@ export default function ManageDealsClient({ storeId }: { storeId: string }) {
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
           price: price.trim(),
-          description,
+          description: description.trim() || undefined,
           title: title.trim() || undefined,
           expires_at: dateInputToIso(expiresDate),
         }),

--- a/app/(dashboard)/dashboard/deals/ManageDealsClient.tsx
+++ b/app/(dashboard)/dashboard/deals/ManageDealsClient.tsx
@@ -38,10 +38,13 @@ export default function ManageDealsClient({ storeId }: { storeId: string }) {
   const [description, setDescription] = useState("");
   const [title, setTitle] = useState("");
   const [expiresDate, setExpiresDate] = useState("");
-  const [error, setError] = useState<string | null>(null);
+  const [formError, setFormError] = useState<string | null>(null);
+  const [reuseErrors, setReuseErrors] = useState<Record<string, string | undefined>>({});
   const [submitting, setSubmitting] = useState(false);
+  const [reusingIds, setReusingIds] = useState<Set<string>>(new Set());
   const [reuseDates, setReuseDates] = useState<Record<string, string>>({});
   const [pastDealsVisible, setPastDealsVisible] = useState(PAST_DEALS_PAGE_SIZE);
+  const todayDate = new Date().toISOString().slice(0, 10);
 
   const load = useCallback(async () => {
     setLoadError(null);
@@ -78,9 +81,9 @@ export default function ManageDealsClient({ storeId }: { storeId: string }) {
 
   async function onSubmit(e: React.FormEvent) {
     e.preventDefault();
-    setError(null);
+    setFormError(null);
     if (!expiresDate) {
-      setError("Expiry date is required.");
+      setFormError("Expiry date is required.");
       return;
     }
     setSubmitting(true);
@@ -97,7 +100,7 @@ export default function ManageDealsClient({ storeId }: { storeId: string }) {
       });
       const data = await res.json().catch(() => ({}));
       if (!res.ok) {
-        setError(typeof data.error === "string" ? data.error : "Could not post deal.");
+        setFormError(typeof data.error === "string" ? data.error : "Could not post deal.");
         return;
       }
       setPrice("");
@@ -111,36 +114,64 @@ export default function ManageDealsClient({ storeId }: { storeId: string }) {
   }
 
   async function reuseDeal(sourceId: string) {
+    if (reusingIds.has(sourceId)) return;
     const dateStr = reuseDates[sourceId];
     if (!dateStr) {
-      setError("Choose a new expiry date before reusing a past deal.");
+      setReuseErrors((prev) => ({
+        ...prev,
+        [sourceId]: "Choose a new expiry date before reusing this past deal.",
+      }));
       return;
     }
-    setError(null);
-    const res = await fetch(`/api/stores/${storeId}/deals`, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({
-        source_deal_id: sourceId,
-        expires_at: dateInputToIso(dateStr),
-      }),
+    setReuseErrors((prev) => ({ ...prev, [sourceId]: undefined }));
+    setReusingIds((prev) => {
+      const next = new Set(prev);
+      next.add(sourceId);
+      return next;
     });
-    const data = await res.json().catch(() => ({}));
-    if (!res.ok) {
-      setError(typeof data.error === "string" ? data.error : "Could not reuse deal.");
-      return;
+    try {
+      const res = await fetch(`/api/stores/${storeId}/deals`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          source_deal_id: sourceId,
+          expires_at: dateInputToIso(dateStr),
+        }),
+      });
+      const data = await res.json().catch(() => ({}));
+      if (!res.ok) {
+        setReuseErrors((prev) => ({
+          ...prev,
+          [sourceId]: typeof data.error === "string" ? data.error : "Could not reuse deal.",
+        }));
+        return;
+      }
+      setReuseDates((prev) => {
+        const next = { ...prev };
+        delete next[sourceId];
+        return next;
+      });
+      await load();
+    } finally {
+      setReusingIds((prev) => {
+        const next = new Set(prev);
+        next.delete(sourceId);
+        return next;
+      });
     }
-    await load();
   }
 
   async function removeDeal(dealId: string) {
-    setError(null);
+    setReuseErrors((prev) => ({ ...prev, [dealId]: undefined }));
     const res = await fetch(`/api/stores/${storeId}/deals/${dealId}`, {
       method: "DELETE",
     });
     const data = await res.json().catch(() => ({}));
     if (!res.ok) {
-      setError(typeof data.error === "string" ? data.error : "Could not remove deal.");
+      setReuseErrors((prev) => ({
+        ...prev,
+        [dealId]: typeof data.error === "string" ? data.error : "Could not remove deal.",
+      }));
       return;
     }
     setPastDealsVisible(PAST_DEALS_PAGE_SIZE);
@@ -166,9 +197,9 @@ export default function ManageDealsClient({ storeId }: { storeId: string }) {
       <div className="bg-white rounded-2xl border border-gray-200 p-6 mb-6">
         <h2 className="text-[17px] font-semibold text-gray-800 mb-4">Post a deal</h2>
         <form onSubmit={onSubmit} className="space-y-4">
-          {error && (
+          {formError && (
             <div className="text-[13px] text-red-700 bg-red-50 border border-red-100 rounded-lg px-3 py-2">
-              {error}
+              {formError}
             </div>
           )}
           <div>
@@ -218,6 +249,7 @@ export default function ManageDealsClient({ storeId }: { storeId: string }) {
             <input
               type="date"
               required
+              min={todayDate}
               value={expiresDate}
               onChange={(e) => setExpiresDate(e.target.value)}
               className="w-full px-3.5 py-2.5 rounded-md border-[1.5px] border-gray-200 text-[15px] bg-white outline-none focus:border-green-400 transition-colors"
@@ -293,19 +325,24 @@ export default function ManageDealsClient({ storeId }: { storeId: string }) {
               <div className="flex flex-col gap-2 shrink-0 w-full sm:w-auto">
                 <input
                   type="date"
+                  min={todayDate}
                   value={reuseDates[deal.id] ?? ""}
                   onChange={(e) =>
                     setReuseDates((prev) => ({ ...prev, [deal.id]: e.target.value }))
                   }
                   className="px-2 py-1.5 rounded-md border border-gray-200 text-[13px]"
                 />
+                {reuseErrors[deal.id] && (
+                  <div className="text-[12px] text-red-700">{reuseErrors[deal.id]}</div>
+                )}
                 <div className="flex flex-wrap gap-2">
                   <button
                     type="button"
                     onClick={() => reuseDeal(deal.id)}
+                    disabled={reusingIds.has(deal.id)}
                     className="px-3 py-1.5 rounded-md text-[12px] font-medium border border-gray-200 hover:bg-green-50 hover:text-green-700 hover:border-green-200 transition-colors text-gray-600"
                   >
-                    Reuse with new expiry
+                    {reusingIds.has(deal.id) ? "Reusing…" : "Reuse with new expiry"}
                   </button>
                   <button
                     type="button"

--- a/app/api/stores/[id]/deals/route.ts
+++ b/app/api/stores/[id]/deals/route.ts
@@ -111,9 +111,6 @@ export async function POST(request: NextRequest, context: RouteContext) {
     if (typeof body.source_deal_id !== "string" || !body.source_deal_id.trim()) {
       return NextResponse.json({ error: "source_deal_id must be a non-empty string" }, { status: 400 });
     }
-  }
-
-  if (hasSourceDealId) {
     const source = await prisma.deal.findFirst({
       where: { id: body.source_deal_id, storeId, deletedAt: null },
     });

--- a/app/api/stores/[id]/deals/route.ts
+++ b/app/api/stores/[id]/deals/route.ts
@@ -106,7 +106,14 @@ export async function POST(request: NextRequest, context: RouteContext) {
     return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
   }
 
-  if (body.source_deal_id) {
+  const hasSourceDealId = Object.prototype.hasOwnProperty.call(body, "source_deal_id");
+  if (hasSourceDealId) {
+    if (typeof body.source_deal_id !== "string" || !body.source_deal_id.trim()) {
+      return NextResponse.json({ error: "source_deal_id must be a non-empty string" }, { status: 400 });
+    }
+  }
+
+  if (hasSourceDealId) {
     const source = await prisma.deal.findFirst({
       where: { id: body.source_deal_id, storeId, deletedAt: null },
     });

--- a/scripts/deals-machine-tests.ts
+++ b/scripts/deals-machine-tests.ts
@@ -73,6 +73,55 @@ async function main() {
   const createdId = (valid.json as { deal?: { id?: string } })?.deal?.id;
   assert.ok(createdId, "Expected created deal id");
 
+  // 1b) POST source_deal_id valid => 201 with new id and timestamp
+  const duplicateExpiry = new Date(Date.now() + 3 * 60 * 60 * 1000).toISOString();
+  const duplicate = await postJson(
+    `/api/stores/${STORE_ID}/deals`,
+    { source_deal_id: createdId, expires_at: duplicateExpiry, price: 4.25 },
+    cookieHeader,
+  );
+  assert.equal(
+    duplicate.res.status,
+    201,
+    "Valid source_deal_id duplication should return 201",
+  );
+  const duplicatedDeal = (duplicate.json as { deal?: { id?: string; createdAt?: string } })?.deal;
+  assert.ok(duplicatedDeal?.id, "Expected duplicated deal id");
+  assert.notEqual(
+    duplicatedDeal?.id,
+    createdId,
+    "Duplicated deal must receive a new identifier",
+  );
+  assert.ok(
+    typeof duplicatedDeal?.createdAt === "string",
+    "Duplicated deal must include a creation timestamp",
+  );
+
+  // 1c) POST source_deal_id invalid => 400 and no insertion
+  const beforeInvalidCount = await prisma.deal.count({ where: { storeId: STORE_ID } });
+  const invalidDuplicate = await postJson(
+    `/api/stores/${STORE_ID}/deals`,
+    { source_deal_id: "not-a-real-deal-id", expires_at: duplicateExpiry },
+    cookieHeader,
+  );
+  assert.equal(
+    invalidDuplicate.res.status,
+    400,
+    "Invalid source_deal_id should return 400",
+  );
+  const afterInvalidCount = await prisma.deal.count({ where: { storeId: STORE_ID } });
+  assert.equal(
+    afterInvalidCount,
+    beforeInvalidCount,
+    "Invalid source_deal_id must not create a new deal",
+  );
+  const blankSource = await postJson(
+    `/api/stores/${STORE_ID}/deals`,
+    { source_deal_id: "", expires_at: duplicateExpiry },
+    cookieHeader,
+  );
+  assert.equal(blankSource.res.status, 400, "Blank source_deal_id should return 400");
+
   // 2) POST missing field / past expiry => 400
   const missing = await postJson(
     `/api/stores/${STORE_ID}/deals`,
@@ -174,9 +223,15 @@ async function main() {
 
   // Cleanup test deals
   await prisma.ownerNotification.deleteMany({
-    where: { dealId: { in: [createdId!, soonDeal.id, deleteId!] } },
+    where: {
+      dealId: {
+        in: [createdId!, duplicatedDeal!.id!, soonDeal.id, deleteId!],
+      },
+    },
   });
-  await prisma.deal.deleteMany({ where: { id: { in: [createdId!, soonDeal.id, deleteId!] } } });
+  await prisma.deal.deleteMany({
+    where: { id: { in: [createdId!, duplicatedDeal!.id!, soonDeal.id, deleteId!] } },
+  });
 
   console.log("All machine deal criteria checks passed.");
 }

--- a/scripts/deals-machine-tests.ts
+++ b/scripts/deals-machine-tests.ts
@@ -115,6 +115,22 @@ async function main() {
     beforeInvalidCount,
     "Invalid source_deal_id must not create a new deal",
   );
+  const crossStoreDuplicate = await postJson(
+    `/api/stores/${STORE_ID}/deals`,
+    { source_deal_id: ids.deals.crescentHistorical, expires_at: duplicateExpiry },
+    cookieHeader,
+  );
+  assert.equal(
+    crossStoreDuplicate.res.status,
+    400,
+    "source_deal_id from another store should return 400",
+  );
+  const afterCrossStoreCount = await prisma.deal.count({ where: { storeId: STORE_ID } });
+  assert.equal(
+    afterCrossStoreCount,
+    beforeInvalidCount,
+    "Cross-store source_deal_id must not create a new deal",
+  );
   const blankSource = await postJson(
     `/api/stores/${STORE_ID}/deals`,
     { source_deal_id: "", expires_at: duplicateExpiry },


### PR DESCRIPTION
## Summary
- Add a **Reuse with new expiry** action to past deals in the owner dashboard so store owners can repost promotions in one click.
- Wire the reuse action to `POST /api/stores/:id/deals` with `source_deal_id` and a newly selected `expires_at`, creating a fresh deal record from the previous one.
- Ensure reused deals refresh immediately in the dashboard list after successful creation.

## Why
- Store owners frequently run similar promotions and should not need to recreate deals from scratch each time.
- A one-action reuse flow reduces posting friction and makes it more likely owners keep deals current for shoppers.

## Test Plan
- [x] Confirm past deals are visible in owner dashboard.
- [x] Click **Reuse with new expiry** on an expired/past deal, set a future date, and verify a new deal is created.
- [x] Verify the reused deal appears in the owner list immediately after action.
- [x] Verify shoppers can see the reused deal once active via public deals surfaces.