### PR TITLE
feat: edit/delete postings

### DIFF
--- a/app/(dashboard)/dashboard/deals/ManageDealsClient.tsx
+++ b/app/(dashboard)/dashboard/deals/ManageDealsClient.tsx
@@ -20,6 +20,10 @@ function dateInputToIso(dateStr: string): string {
   return new Date(Date.UTC(y, m - 1, d, 23, 59, 59, 999)).toISOString();
 }
 
+function isoToDateInput(iso: string): string {
+  return new Date(iso).toISOString().slice(0, 10);
+}
+
 function dealIsActive(d: ApiDeal): boolean {
   return !d.isExpired && new Date(d.expiresAt).getTime() > Date.now();
 }
@@ -44,6 +48,13 @@ export default function ManageDealsClient({ storeId }: { storeId: string }) {
   const [reusingIds, setReusingIds] = useState<Set<string>>(new Set());
   const [reuseDates, setReuseDates] = useState<Record<string, string>>({});
   const [pastDealsVisible, setPastDealsVisible] = useState(PAST_DEALS_PAGE_SIZE);
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [editPrice, setEditPrice] = useState("");
+  const [editDescription, setEditDescription] = useState("");
+  const [editTitle, setEditTitle] = useState("");
+  const [editExpiresDate, setEditExpiresDate] = useState("");
+  const [editError, setEditError] = useState<string | null>(null);
+  const [savingEdit, setSavingEdit] = useState(false);
   const todayDate = new Date().toISOString().slice(0, 10);
 
   const load = useCallback(async () => {
@@ -178,6 +189,64 @@ export default function ManageDealsClient({ storeId }: { storeId: string }) {
     await load();
   }
 
+  function startEdit(deal: ApiDeal) {
+    setEditError(null);
+    setEditingId(deal.id);
+    setEditPrice(deal.price ?? "");
+    setEditDescription(deal.description ?? "");
+    setEditTitle(deal.title ?? "");
+    setEditExpiresDate(isoToDateInput(deal.expiresAt));
+  }
+
+  function cancelEdit() {
+    setEditingId(null);
+    setEditPrice("");
+    setEditDescription("");
+    setEditTitle("");
+    setEditExpiresDate("");
+    setEditError(null);
+  }
+
+  async function saveEdit(dealId: string) {
+    setEditError(null);
+    if (!editPrice.trim()) {
+      setEditError("Price is required.");
+      return;
+    }
+    if (!editDescription.trim()) {
+      setEditError("Description is required.");
+      return;
+    }
+    if (!editExpiresDate) {
+      setEditError("Expiry date is required.");
+      return;
+    }
+    setSavingEdit(true);
+    try {
+      const res = await fetch(`/api/stores/${storeId}/deals/${dealId}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          price: editPrice.trim(),
+          description: editDescription.trim(),
+          title: editTitle.trim() || editDescription.trim(),
+          expires_at: dateInputToIso(editExpiresDate),
+        }),
+      });
+      const data = await res.json().catch(() => ({}));
+      if (!res.ok) {
+        setEditError(
+          typeof data.error === "string" ? data.error : "Could not update deal.",
+        );
+        return;
+      }
+      await load();
+      cancelEdit();
+    } finally {
+      setSavingEdit(false);
+    }
+  }
+
   const activeDeals = deals.filter(dealIsActive);
   const inactiveDeals = deals.filter((d) => !dealIsActive(d));
   const visibleInactive = inactiveDeals.slice(0, pastDealsVisible);
@@ -286,22 +355,107 @@ export default function ManageDealsClient({ storeId }: { storeId: string }) {
           {activeDeals.map((deal) => (
             <div
               key={deal.id}
-              className="flex items-center gap-3 p-3.5 bg-white border border-gray-200 rounded-xl hover:border-gray-400 transition-colors"
+              className="p-3.5 bg-white border border-gray-200 rounded-xl hover:border-gray-400 transition-colors"
             >
-              <div className="text-2xl w-11 h-11 rounded-md bg-gray-50 flex items-center justify-center shrink-0">
-                🏷
+              <div className="flex items-center gap-3">
+                <div className="text-2xl w-11 h-11 rounded-md bg-gray-50 flex items-center justify-center shrink-0">
+                  🏷
+                </div>
+                <div className="flex-1 min-w-0">
+                  <div className="font-medium text-[15px] truncate">{deal.title}</div>
+                  <div className="text-[12px] text-gray-400 mt-0.5">{formatDealMeta(deal)}</div>
+                </div>
+                <div className="flex gap-2">
+                  <button
+                    type="button"
+                    onClick={() => startEdit(deal)}
+                    className="shrink-0 px-2.5 py-1 rounded-md text-[12px] font-medium text-gray-600 border border-gray-200 hover:bg-gray-100 transition-colors"
+                  >
+                    Edit
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => removeDeal(deal.id)}
+                    className="shrink-0 px-2.5 py-1 rounded-md text-[12px] font-medium text-gray-500 border border-gray-200 hover:bg-red-50 hover:text-red-700 hover:border-red-100 transition-colors"
+                  >
+                    Remove
+                  </button>
+                </div>
               </div>
-              <div className="flex-1 min-w-0">
-                <div className="font-medium text-[15px] truncate">{deal.title}</div>
-                <div className="text-[12px] text-gray-400 mt-0.5">{formatDealMeta(deal)}</div>
-              </div>
-              <button
-                type="button"
-                onClick={() => removeDeal(deal.id)}
-                className="shrink-0 px-2.5 py-1 rounded-md text-[12px] font-medium text-gray-500 border border-gray-200 hover:bg-red-50 hover:text-red-700 hover:border-red-100 transition-colors"
-              >
-                Remove
-              </button>
+              {editingId === deal.id && (
+                <div className="mt-3 border-t border-gray-100 pt-3 grid grid-cols-1 sm:grid-cols-2 gap-3">
+                  {editError && (
+                    <div className="sm:col-span-2 text-[13px] text-red-700 bg-red-50 border border-red-100 rounded-lg px-3 py-2">
+                      {editError}
+                    </div>
+                  )}
+                  <div>
+                    <label className="block text-[12px] font-medium text-gray-600 mb-1">
+                      Price (USD)
+                    </label>
+                    <input
+                      type="number"
+                      inputMode="decimal"
+                      min={0.01}
+                      step="0.01"
+                      value={editPrice}
+                      onChange={(e) => setEditPrice(e.target.value)}
+                      className="w-full px-2.5 py-2 rounded-md border border-gray-200 text-[14px] bg-white outline-none focus:border-green-400 transition-colors"
+                    />
+                  </div>
+                  <div>
+                    <label className="block text-[12px] font-medium text-gray-600 mb-1">
+                      Expiry date
+                    </label>
+                    <input
+                      type="date"
+                      min={todayDate}
+                      value={editExpiresDate}
+                      onChange={(e) => setEditExpiresDate(e.target.value)}
+                      className="w-full px-2.5 py-2 rounded-md border border-gray-200 text-[14px] bg-white outline-none focus:border-green-400 transition-colors"
+                    />
+                  </div>
+                  <div className="sm:col-span-2">
+                    <label className="block text-[12px] font-medium text-gray-600 mb-1">
+                      Description
+                    </label>
+                    <textarea
+                      rows={2}
+                      value={editDescription}
+                      onChange={(e) => setEditDescription(e.target.value)}
+                      className="w-full px-2.5 py-2 rounded-md border border-gray-200 text-[14px] bg-white outline-none focus:border-green-400 transition-colors resize-y"
+                    />
+                  </div>
+                  <div className="sm:col-span-2">
+                    <label className="block text-[12px] font-medium text-gray-600 mb-1">
+                      Title
+                    </label>
+                    <input
+                      value={editTitle}
+                      onChange={(e) => setEditTitle(e.target.value)}
+                      className="w-full px-2.5 py-2 rounded-md border border-gray-200 text-[14px] bg-white outline-none focus:border-green-400 transition-colors"
+                    />
+                  </div>
+                  <div className="sm:col-span-2 flex gap-2">
+                    <button
+                      type="button"
+                      onClick={() => void saveEdit(deal.id)}
+                      disabled={savingEdit}
+                      className="px-3 py-1.5 rounded-md text-[12px] font-medium text-white bg-green-600 hover:bg-green-800 transition-colors disabled:opacity-60"
+                    >
+                      {savingEdit ? "Saving..." : "Save"}
+                    </button>
+                    <button
+                      type="button"
+                      onClick={cancelEdit}
+                      disabled={savingEdit}
+                      className="px-3 py-1.5 rounded-md text-[12px] font-medium border border-gray-200 text-gray-600 hover:bg-gray-100 transition-colors disabled:opacity-60"
+                    >
+                      Cancel
+                    </button>
+                  </div>
+                </div>
+              )}
             </div>
           ))}
           {visibleInactive.map((deal) => (

--- a/app/(dashboard)/dashboard/deals/ManageDealsClient.tsx
+++ b/app/(dashboard)/dashboard/deals/ManageDealsClient.tsx
@@ -190,6 +190,7 @@ export default function ManageDealsClient({ storeId }: { storeId: string }) {
   }
 
   function startEdit(deal: ApiDeal) {
+    if (savingEdit) return;
     setEditError(null);
     setEditingId(deal.id);
     setEditPrice(deal.price ?? "");
@@ -369,7 +370,8 @@ export default function ManageDealsClient({ storeId }: { storeId: string }) {
                   <button
                     type="button"
                     onClick={() => startEdit(deal)}
-                    className="shrink-0 px-2.5 py-1 rounded-md text-[12px] font-medium text-gray-600 border border-gray-200 hover:bg-gray-100 transition-colors"
+                    disabled={savingEdit}
+                    className="shrink-0 px-2.5 py-1 rounded-md text-[12px] font-medium text-gray-600 border border-gray-200 hover:bg-gray-100 transition-colors disabled:opacity-60 disabled:cursor-not-allowed"
                   >
                     Edit
                   </button>

--- a/app/(dashboard)/dashboard/posts/ManageFreshUpdatesClient.tsx
+++ b/app/(dashboard)/dashboard/posts/ManageFreshUpdatesClient.tsx
@@ -22,6 +22,11 @@ export default function ManageFreshUpdatesClient({ storeId }: { storeId: string 
   const [error, setError] = useState<string | null>(null);
   const [success, setSuccess] = useState<string | null>(null);
   const [submitting, setSubmitting] = useState(false);
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [editItemName, setEditItemName] = useState("");
+  const [editNote, setEditNote] = useState("");
+  const [savingEdit, setSavingEdit] = useState(false);
+  const [deletingId, setDeletingId] = useState<string | null>(null);
 
   const mountedRef = useRef(true);
   const submitAbortRef = useRef<AbortController | null>(null);
@@ -125,6 +130,102 @@ export default function ManageFreshUpdatesClient({ storeId }: { storeId: string 
       setError("Could not post update.");
     } finally {
       if (mountedRef.current && !ac.signal.aborted) setSubmitting(false);
+    }
+  }
+
+  function beginEdit(update: ApiFreshUpdate) {
+    setError(null);
+    setSuccess(null);
+    setEditingId(update.id);
+    setEditItemName(update.itemName);
+    setEditNote(update.note ?? "");
+  }
+
+  function cancelEdit() {
+    setEditingId(null);
+    setEditItemName("");
+    setEditNote("");
+  }
+
+  async function saveEdit(postId: string) {
+    setError(null);
+    setSuccess(null);
+    const name = editItemName.trim();
+    if (!name) {
+      setError("Item name is required.");
+      return;
+    }
+
+    setSavingEdit(true);
+    try {
+      const res = await fetch(`/api/stores/${storeId}/posts/${postId}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          item_name: name,
+          note: editNote.trim() || "",
+        }),
+      });
+      const data = (await res.json().catch(() => ({}))) as {
+        error?: string;
+        post?: {
+          id: string;
+          itemName: string;
+          note: string | null;
+          createdAt: string;
+        };
+      };
+      if (!res.ok) {
+        setError(typeof data.error === "string" ? data.error : "Could not save edits.");
+        return;
+      }
+
+      const post = data.post;
+      if (post) {
+        setUpdates((current) =>
+          current.map((u) =>
+            u.id === post.id
+              ? {
+                  ...u,
+                  itemName: post.itemName,
+                  note: post.note,
+                }
+              : u,
+          ),
+        );
+      }
+      cancelEdit();
+      setSuccess("Post updated.");
+    } catch {
+      setError("Could not save edits.");
+    } finally {
+      if (mountedRef.current) setSavingEdit(false);
+    }
+  }
+
+  async function deletePost(postId: string) {
+    const confirmed = window.confirm("Delete this post? This cannot be undone.");
+    if (!confirmed) return;
+
+    setError(null);
+    setSuccess(null);
+    setDeletingId(postId);
+    try {
+      const res = await fetch(`/api/stores/${storeId}/posts/${postId}`, {
+        method: "DELETE",
+      });
+      const data = (await res.json().catch(() => ({}))) as { error?: string };
+      if (!res.ok) {
+        setError(typeof data.error === "string" ? data.error : "Could not delete post.");
+        return;
+      }
+      setUpdates((current) => current.filter((u) => u.id !== postId));
+      if (editingId === postId) cancelEdit();
+      setSuccess("Post deleted.");
+    } catch {
+      setError("Could not delete post.");
+    } finally {
+      if (mountedRef.current) setDeletingId(null);
     }
   }
 
@@ -237,17 +338,39 @@ export default function ManageFreshUpdatesClient({ storeId }: { storeId: string 
                 }`}
               >
                 <div className="min-w-0">
-                  <div
-                    className={`font-medium text-gray-800 truncate ${
-                      stale ? "text-[14px]" : "text-[15px]"
-                    }`}
-                  >
-                    {u.itemName}
-                  </div>
-                  {u.note && (
-                    <div className="text-[13px] text-gray-500 mt-0.5 line-clamp-2">
-                      {u.note}
+                  {editingId === u.id ? (
+                    <div className="space-y-2">
+                      <input
+                        value={editItemName}
+                        maxLength={MAX_ITEM_NAME_LEN}
+                        onChange={(e) => setEditItemName(e.target.value)}
+                        className="w-full px-2.5 py-1.5 rounded-md border border-gray-300 text-[14px] text-gray-800 bg-white outline-none focus:border-green-400 transition-colors"
+                        aria-label="Edit item name"
+                      />
+                      <textarea
+                        value={editNote}
+                        maxLength={MAX_NOTE_LEN}
+                        rows={2}
+                        onChange={(e) => setEditNote(e.target.value)}
+                        className="w-full px-2.5 py-1.5 rounded-md border border-gray-300 text-[13px] text-gray-700 bg-white outline-none focus:border-green-400 transition-colors resize-y min-h-[70px]"
+                        aria-label="Edit note"
+                      />
                     </div>
+                  ) : (
+                    <>
+                      <div
+                        className={`font-medium text-gray-800 truncate ${
+                          stale ? "text-[14px]" : "text-[15px]"
+                        }`}
+                      >
+                        {u.itemName}
+                      </div>
+                      {u.note && (
+                        <div className="text-[13px] text-gray-500 mt-0.5 line-clamp-2">
+                          {u.note}
+                        </div>
+                      )}
+                    </>
                   )}
                 </div>
                 <div className="flex items-center gap-2 shrink-0">
@@ -260,6 +383,44 @@ export default function ManageFreshUpdatesClient({ storeId }: { storeId: string 
                   >
                     {when ?? "—"}
                   </span>
+                  {editingId === u.id ? (
+                    <>
+                      <button
+                        type="button"
+                        onClick={() => void saveEdit(u.id)}
+                        disabled={savingEdit}
+                        className="text-[12px] px-2 py-0.5 rounded-md font-medium text-white bg-green-600 hover:bg-green-700 disabled:opacity-60"
+                      >
+                        {savingEdit ? "Saving..." : "Save"}
+                      </button>
+                      <button
+                        type="button"
+                        onClick={cancelEdit}
+                        disabled={savingEdit}
+                        className="text-[12px] px-2 py-0.5 rounded-md font-medium text-gray-600 bg-gray-100 hover:bg-gray-200 disabled:opacity-60"
+                      >
+                        Cancel
+                      </button>
+                    </>
+                  ) : (
+                    <>
+                      <button
+                        type="button"
+                        onClick={() => beginEdit(u)}
+                        className="text-[12px] px-2 py-0.5 rounded-md font-medium text-gray-700 bg-gray-100 hover:bg-gray-200"
+                      >
+                        Edit
+                      </button>
+                      <button
+                        type="button"
+                        onClick={() => void deletePost(u.id)}
+                        disabled={deletingId === u.id}
+                        className="text-[12px] px-2 py-0.5 rounded-md font-medium text-red-700 bg-red-50 hover:bg-red-100 disabled:opacity-60"
+                      >
+                        {deletingId === u.id ? "Deleting..." : "Delete"}
+                      </button>
+                    </>
+                  )}
                 </div>
               </li>
             );

--- a/app/(public)/stores/[id]/page.tsx
+++ b/app/(public)/stores/[id]/page.tsx
@@ -9,10 +9,10 @@ import {
   FRESH_UPDATE_PUBLIC_WINDOW_MS,
 } from "@/lib/fresh-updates";
 import { prisma } from "@/lib/prisma";
-import { relativeTime } from "@/lib/time";
 import { notFound } from "next/navigation";
 import Link from "next/link";
 import ItemAvailabilitySearch from "@/components/ItemAvailabilitySearch";
+import StoreFreshUpdatesFeed from "@/components/StoreFreshUpdatesFeed";
 
 export const dynamic = "force-dynamic";
 
@@ -54,6 +54,13 @@ export default async function StoreProfilePage({
     store.freshUpdates,
     asOf,
   );
+  const initialFreshUpdates = freshUpdatesDisplay.map((update) => ({
+    id: update.id,
+    itemName: update.itemName,
+    note: update.note,
+    createdAt: update.createdAt.toISOString(),
+    isStale: update.isStale,
+  }));
 
   const hours = store.hours as { open?: string; close?: string } | null;
 
@@ -114,47 +121,10 @@ export default async function StoreProfilePage({
         <h2 className="text-[17px] font-semibold text-gray-800 mb-4 flex items-center gap-2">
           🌿 Fresh Today
         </h2>
-        {freshUpdatesDisplay.length === 0 ? (
-          <div className="text-center py-8">
-            <div className="text-[42px] mb-3">🫙</div>
-            <h3 className="text-[16px] font-semibold text-gray-800 mb-1">
-              No recent updates
-            </h3>
-            <p className="text-[14px] text-gray-400">
-              This store hasn&apos;t posted any inventory updates in the last 7
-              days.
-            </p>
-          </div>
-        ) : (
-          freshUpdatesDisplay.map((update) => (
-            <div
-              key={update.id}
-              className={`flex justify-between items-start py-3 border-b border-gray-100 last:border-b-0 ${
-                update.isStale ? "opacity-40" : ""
-              }`}
-            >
-              <div>
-                <div className="font-medium text-[15px]">
-                  {update.itemName}
-                </div>
-                {update.note && (
-                  <div className="text-[13px] text-gray-400 mt-0.5">
-                    {update.note}
-                  </div>
-                )}
-              </div>
-              <span
-                className={`text-[12px] px-2 py-0.5 rounded-full whitespace-nowrap ml-2 shrink-0 ${
-                  update.isStale
-                    ? "bg-gray-100 text-gray-400"
-                    : "bg-green-50 text-green-600"
-                }`}
-              >
-                {relativeTime(update.createdAt) ?? "—"}
-              </span>
-            </div>
-          ))
-        )}
+        <StoreFreshUpdatesFeed
+          storeId={store.id}
+          initialUpdates={initialFreshUpdates}
+        />
       </div>
 
       {/* Deals This Week — Story 2 */}

--- a/app/api/stores/[id]/deals/[dealId]/route.ts
+++ b/app/api/stores/[id]/deals/[dealId]/route.ts
@@ -71,13 +71,6 @@ export async function PATCH(request: NextRequest, context: RouteContext) {
     );
   }
 
-  const existing = await prisma.deal.findFirst({
-    where: { id: dealId, storeId, deletedAt: null },
-  });
-  if (!existing) {
-    return NextResponse.json({ error: "Deal not found" }, { status: 404 });
-  }
-
   const data: {
     title?: string;
     description?: string;
@@ -141,11 +134,19 @@ export async function PATCH(request: NextRequest, context: RouteContext) {
     data.expiryNotifiedAt = null;
   }
 
-  const deal = await prisma.deal.update({
-    where: { id: dealId },
+  const updated = await prisma.deal.updateMany({
+    where: { id: dealId, storeId, deletedAt: null },
     data,
+  });
+  if (updated.count === 0) {
+    return NextResponse.json({ error: "Deal not found" }, { status: 404 });
+  }
+
+  const deal = await prisma.deal.findUnique({
+    where: { id: dealId },
     select: {
       id: true,
+      storeId: true,
       title: true,
       description: true,
       price: true,
@@ -154,8 +155,12 @@ export async function PATCH(request: NextRequest, context: RouteContext) {
       isExpired: true,
       createdAt: true,
       sourceDealId: true,
+      deletedAt: true,
     },
   });
+  if (!deal || deal.storeId !== storeId || deal.deletedAt !== null) {
+    return NextResponse.json({ error: "Deal not found" }, { status: 404 });
+  }
 
   return NextResponse.json({ deal: dealJson(deal) }, { status: 200 });
 }
@@ -167,17 +172,13 @@ export async function DELETE(_request: NextRequest, context: RouteContext) {
   const gate = await requireStoreOwnerForStore(storeId);
   if ("response" in gate) return gate.response;
 
-  const deal = await prisma.deal.findFirst({
+  const deleted = await prisma.deal.updateMany({
     where: { id: dealId, storeId, deletedAt: null },
-  });
-  if (!deal) {
-    return NextResponse.json({ error: "Deal not found" }, { status: 404 });
-  }
-
-  await prisma.deal.update({
-    where: { id: dealId },
     data: { deletedAt: new Date() },
   });
+  if (deleted.count === 0) {
+    return NextResponse.json({ error: "Deal not found" }, { status: 404 });
+  }
 
   return NextResponse.json({ ok: true });
 }

--- a/app/api/stores/[id]/deals/[dealId]/route.ts
+++ b/app/api/stores/[id]/deals/[dealId]/route.ts
@@ -1,9 +1,163 @@
 import { NextRequest, NextResponse } from "next/server";
+import { Prisma } from "@/app/generated/prisma/client";
 import { prisma } from "@/lib/prisma";
 import { requireStoreOwnerForStore } from "@/lib/require-store-owner";
 
 interface RouteContext {
   params: Promise<{ id: string; dealId: string }>;
+}
+
+function parsePrice(raw: unknown): { ok: true; value: Prisma.Decimal } | { ok: false; error: string } {
+  if (raw === undefined || raw === null || raw === "") {
+    return { ok: false, error: "price is required" };
+  }
+  const n =
+    typeof raw === "number"
+      ? raw
+      : typeof raw === "string"
+        ? parseFloat(raw)
+        : NaN;
+  if (!Number.isFinite(n)) {
+    return { ok: false, error: "price must be a valid number" };
+  }
+  if (n <= 0) {
+    return { ok: false, error: "price must be greater than zero" };
+  }
+  return { ok: true, value: new Prisma.Decimal(n.toFixed(2)) };
+}
+
+function dealJson(deal: {
+  id: string;
+  title: string;
+  description: string | null;
+  price: Prisma.Decimal | null;
+  discountPct: number | null;
+  expiresAt: Date;
+  isExpired: boolean;
+  createdAt: Date;
+  sourceDealId: string | null;
+}) {
+  return {
+    ...deal,
+    price: deal.price != null ? deal.price.toString() : null,
+    expiresAt: deal.expiresAt.toISOString(),
+    createdAt: deal.createdAt.toISOString(),
+  };
+}
+
+/** Edit a deal posting (owner only). */
+export async function PATCH(request: NextRequest, context: RouteContext) {
+  const { id: storeId, dealId } = await context.params;
+  const gate = await requireStoreOwnerForStore(storeId);
+  if ("response" in gate) return gate.response;
+
+  const body = await request.json().catch(() => null);
+  if (!body || typeof body !== "object") {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  const hasAnyField =
+    Object.prototype.hasOwnProperty.call(body, "title") ||
+    Object.prototype.hasOwnProperty.call(body, "description") ||
+    Object.prototype.hasOwnProperty.call(body, "price") ||
+    Object.prototype.hasOwnProperty.call(body, "expires_at");
+  if (!hasAnyField) {
+    return NextResponse.json(
+      {
+        error:
+          "Provide at least one editable field: title, description, price, or expires_at.",
+      },
+      { status: 400 },
+    );
+  }
+
+  const existing = await prisma.deal.findFirst({
+    where: { id: dealId, storeId, deletedAt: null },
+  });
+  if (!existing) {
+    return NextResponse.json({ error: "Deal not found" }, { status: 404 });
+  }
+
+  const data: {
+    title?: string;
+    description?: string;
+    price?: Prisma.Decimal;
+    expiresAt?: Date;
+    isExpired?: boolean;
+    expiryNotifiedAt?: Date | null;
+  } = {};
+
+  if (Object.prototype.hasOwnProperty.call(body, "title")) {
+    if (typeof body.title !== "string" || !body.title.trim()) {
+      return NextResponse.json(
+        { error: "title must be a non-empty string" },
+        { status: 400 },
+      );
+    }
+    data.title = body.title.trim();
+  }
+
+  if (Object.prototype.hasOwnProperty.call(body, "description")) {
+    if (typeof body.description !== "string" || !body.description.trim()) {
+      return NextResponse.json(
+        { error: "description must be a non-empty string" },
+        { status: 400 },
+      );
+    }
+    data.description = body.description.trim();
+  }
+
+  if (Object.prototype.hasOwnProperty.call(body, "price")) {
+    const parsed = parsePrice(body.price);
+    if (!parsed.ok) {
+      return NextResponse.json({ error: parsed.error }, { status: 400 });
+    }
+    data.price = parsed.value;
+  }
+
+  if (Object.prototype.hasOwnProperty.call(body, "expires_at")) {
+    if (
+      body.expires_at === undefined ||
+      body.expires_at === null ||
+      body.expires_at === ""
+    ) {
+      return NextResponse.json({ error: "expires_at is required" }, { status: 400 });
+    }
+    const expiresAt = new Date(body.expires_at as string);
+    if (Number.isNaN(expiresAt.getTime())) {
+      return NextResponse.json(
+        { error: "expires_at must be a valid date" },
+        { status: 400 },
+      );
+    }
+    if (expiresAt <= new Date()) {
+      return NextResponse.json(
+        { error: "expires_at must be in the future" },
+        { status: 400 },
+      );
+    }
+    data.expiresAt = expiresAt;
+    data.isExpired = false;
+    data.expiryNotifiedAt = null;
+  }
+
+  const deal = await prisma.deal.update({
+    where: { id: dealId },
+    data,
+    select: {
+      id: true,
+      title: true,
+      description: true,
+      price: true,
+      discountPct: true,
+      expiresAt: true,
+      isExpired: true,
+      createdAt: true,
+      sourceDealId: true,
+    },
+  });
+
+  return NextResponse.json({ deal: dealJson(deal) }, { status: 200 });
 }
 
 /** Soft-delete a deal before natural expiry (owner only). */

--- a/app/api/stores/[id]/posts/[postId]/route.ts
+++ b/app/api/stores/[id]/posts/[postId]/route.ts
@@ -21,24 +21,36 @@ export async function PATCH(request: NextRequest, context: RouteContext) {
     return NextResponse.json({ error: parsed.error }, { status: 400 });
   }
 
-  const existing = await prisma.freshUpdate.findFirst({
+  const updated = await prisma.freshUpdate.updateMany({
     where: { id: postId, storeId, deletedAt: null },
+    data: parsed.data,
   });
-  if (!existing) {
+  if (updated.count === 0) {
     return NextResponse.json({ error: "Post not found" }, { status: 404 });
   }
 
-  const post = await prisma.freshUpdate.update({
+  const post = await prisma.freshUpdate.findUnique({
     where: { id: postId },
-    data: parsed.data,
     select: {
       id: true,
       storeId: true,
       itemName: true,
       note: true,
       createdAt: true,
+      deletedAt: true,
     },
   });
+  if (!post || post.storeId !== storeId || post.deletedAt !== null) {
+    return NextResponse.json({ error: "Post not found" }, { status: 404 });
+  }
+
+  const responsePost = {
+    id: post.id,
+    storeId: post.storeId,
+    itemName: post.itemName,
+    note: post.note,
+    createdAt: post.createdAt,
+  };
 
   broadcastPostEvent({
     storeId,
@@ -46,7 +58,7 @@ export async function PATCH(request: NextRequest, context: RouteContext) {
     type: "POST_UPDATE",
   });
 
-  return NextResponse.json({ post }, { status: 200 });
+  return NextResponse.json({ post: responsePost }, { status: 200 });
 }
 
 // Story 13: DELETE /stores/:id/posts/:post_id — soft delete only.
@@ -56,17 +68,13 @@ export async function DELETE(_request: NextRequest, context: RouteContext) {
   const gate = await requireStoreOwnerForStore(storeId);
   if ("response" in gate) return gate.response;
 
-  const existing = await prisma.freshUpdate.findFirst({
+  const deleted = await prisma.freshUpdate.updateMany({
     where: { id: postId, storeId, deletedAt: null },
-  });
-  if (!existing) {
-    return NextResponse.json({ error: "Post not found" }, { status: 404 });
-  }
-
-  await prisma.freshUpdate.update({
-    where: { id: postId },
     data: { deletedAt: new Date() },
   });
+  if (deleted.count === 0) {
+    return NextResponse.json({ error: "Post not found" }, { status: 404 });
+  }
 
   broadcastPostEvent({
     storeId,

--- a/app/api/stores/[id]/posts/[postId]/route.ts
+++ b/app/api/stores/[id]/posts/[postId]/route.ts
@@ -1,0 +1,78 @@
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { broadcastPostEvent } from "@/lib/post-events";
+import { parseFreshUpdatePatchBody } from "@/lib/fresh-updates";
+import { requireStoreOwnerForStore } from "@/lib/require-store-owner";
+
+interface RouteContext {
+  params: Promise<{ id: string; postId: string }>;
+}
+
+// Story 13: PATCH /stores/:id/posts/:post_id — owner edits a post.
+export async function PATCH(request: NextRequest, context: RouteContext) {
+  const { id: storeId, postId } = await context.params;
+
+  const gate = await requireStoreOwnerForStore(storeId);
+  if ("response" in gate) return gate.response;
+
+  const body = await request.json().catch(() => null);
+  const parsed = parseFreshUpdatePatchBody(body);
+  if (!parsed.ok) {
+    return NextResponse.json({ error: parsed.error }, { status: 400 });
+  }
+
+  const existing = await prisma.freshUpdate.findFirst({
+    where: { id: postId, storeId, deletedAt: null },
+  });
+  if (!existing) {
+    return NextResponse.json({ error: "Post not found" }, { status: 404 });
+  }
+
+  const post = await prisma.freshUpdate.update({
+    where: { id: postId },
+    data: parsed.data,
+    select: {
+      id: true,
+      storeId: true,
+      itemName: true,
+      note: true,
+      createdAt: true,
+    },
+  });
+
+  broadcastPostEvent({
+    storeId,
+    postId,
+    type: "POST_UPDATE",
+  });
+
+  return NextResponse.json({ post }, { status: 200 });
+}
+
+// Story 13: DELETE /stores/:id/posts/:post_id — soft delete only.
+export async function DELETE(_request: NextRequest, context: RouteContext) {
+  const { id: storeId, postId } = await context.params;
+
+  const gate = await requireStoreOwnerForStore(storeId);
+  if ("response" in gate) return gate.response;
+
+  const existing = await prisma.freshUpdate.findFirst({
+    where: { id: postId, storeId, deletedAt: null },
+  });
+  if (!existing) {
+    return NextResponse.json({ error: "Post not found" }, { status: 404 });
+  }
+
+  await prisma.freshUpdate.update({
+    where: { id: postId },
+    data: { deletedAt: new Date() },
+  });
+
+  broadcastPostEvent({
+    storeId,
+    postId,
+    type: "POST_DELETE",
+  });
+
+  return NextResponse.json({ ok: true });
+}

--- a/app/api/stores/[id]/posts/events/route.ts
+++ b/app/api/stores/[id]/posts/events/route.ts
@@ -1,0 +1,50 @@
+import { NextRequest } from "next/server";
+import { subscribeToPostEvents, type PostEventPayload } from "@/lib/post-events";
+
+interface RouteContext {
+  params: Promise<{ id: string }>;
+}
+
+function toSseMessage(event: string, data: unknown) {
+  return `event: ${event}\ndata: ${JSON.stringify(data)}\n\n`;
+}
+
+export async function GET(request: NextRequest, context: RouteContext) {
+  const { id: storeId } = await context.params;
+  const encoder = new TextEncoder();
+
+  const stream = new ReadableStream<Uint8Array>({
+    start(controller) {
+      controller.enqueue(
+        encoder.encode(toSseMessage("ready", { storeId, ok: true })),
+      );
+
+      const onPostEvent = (payload: PostEventPayload) => {
+        controller.enqueue(encoder.encode(toSseMessage("post-event", payload)));
+      };
+
+      const unsubscribe = subscribeToPostEvents(storeId, onPostEvent);
+      const keepAlive = setInterval(() => {
+        controller.enqueue(encoder.encode(": keepalive\n\n"));
+      }, 15000);
+
+      const cleanup = () => {
+        clearInterval(keepAlive);
+        unsubscribe();
+      };
+
+      request.signal.addEventListener("abort", cleanup, { once: true });
+    },
+    cancel() {
+      // cleanup is handled by request abort listener
+    },
+  });
+
+  return new Response(stream, {
+    headers: {
+      "Content-Type": "text/event-stream; charset=utf-8",
+      "Cache-Control": "no-cache, no-transform",
+      Connection: "keep-alive",
+    },
+  });
+}

--- a/app/api/stores/[id]/updates/route.ts
+++ b/app/api/stores/[id]/updates/route.ts
@@ -5,6 +5,7 @@ import {
   FRESH_UPDATE_PUBLIC_WINDOW_MS,
   parseFreshUpdatePostBody,
 } from "@/lib/fresh-updates";
+import { broadcastPostEvent } from "@/lib/post-events";
 import { prisma } from "@/lib/prisma";
 import { requireStoreOwnerForStore } from "@/lib/require-store-owner";
 
@@ -71,6 +72,12 @@ export async function POST(
       itemName: parsed.itemName,
       note: parsed.note,
     },
+  });
+
+  broadcastPostEvent({
+    storeId,
+    postId: update.id,
+    type: "POST_UPDATE",
   });
 
   return NextResponse.json({ update }, { status: 201 });

--- a/app/api/stores/[id]/updates/route.ts
+++ b/app/api/stores/[id]/updates/route.ts
@@ -77,7 +77,7 @@ export async function POST(
   broadcastPostEvent({
     storeId,
     postId: update.id,
-    type: "POST_UPDATE",
+    type: "POST_CREATE",
   });
 
   return NextResponse.json({ update }, { status: 201 });

--- a/components/StoreFreshUpdatesFeed.tsx
+++ b/components/StoreFreshUpdatesFeed.tsx
@@ -37,9 +37,6 @@ export default function StoreFreshUpdatesFeed({
       void reload();
     };
     es.addEventListener("post-event", onPostEvent);
-    es.onerror = () => {
-      es.close();
-    };
     return () => {
       es.removeEventListener("post-event", onPostEvent);
       es.close();

--- a/components/StoreFreshUpdatesFeed.tsx
+++ b/components/StoreFreshUpdatesFeed.tsx
@@ -1,0 +1,91 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { relativeTime } from "@/lib/time";
+
+type FreshUpdate = {
+  id: string;
+  itemName: string;
+  note: string | null;
+  createdAt: string;
+  isStale: boolean;
+};
+
+type ApiResponse = { updates?: FreshUpdate[] };
+
+export default function StoreFreshUpdatesFeed({
+  storeId,
+  initialUpdates,
+}: {
+  storeId: string;
+  initialUpdates: FreshUpdate[];
+}) {
+  const [updates, setUpdates] = useState<FreshUpdate[]>(initialUpdates);
+
+  const reload = useCallback(async () => {
+    const res = await fetch(`/api/stores/${storeId}/updates`, {
+      cache: "no-store",
+    });
+    if (!res.ok) return;
+    const data = (await res.json()) as ApiResponse;
+    setUpdates(data.updates ?? []);
+  }, [storeId]);
+
+  useEffect(() => {
+    const es = new EventSource(`/api/stores/${storeId}/posts/events`);
+    const onPostEvent = () => {
+      void reload();
+    };
+    es.addEventListener("post-event", onPostEvent);
+    es.onerror = () => {
+      es.close();
+    };
+    return () => {
+      es.removeEventListener("post-event", onPostEvent);
+      es.close();
+    };
+  }, [reload, storeId]);
+
+  if (updates.length === 0) {
+    return (
+      <div className="text-center py-8">
+        <div className="text-[42px] mb-3">🫙</div>
+        <h3 className="text-[16px] font-semibold text-gray-800 mb-1">
+          No recent updates
+        </h3>
+        <p className="text-[14px] text-gray-400">
+          This store hasn&apos;t posted any inventory updates in the last 7 days.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <>
+      {updates.map((update) => (
+        <div
+          key={update.id}
+          className={`flex justify-between items-start py-3 border-b border-gray-100 last:border-b-0 ${
+            update.isStale ? "opacity-40" : ""
+          }`}
+        >
+          <div>
+            <div className="font-medium text-[15px]">{update.itemName}</div>
+            {update.note && (
+              <div className="text-[13px] text-gray-400 mt-0.5">{update.note}</div>
+            )}
+          </div>
+          <span
+            className={`text-[12px] px-2 py-0.5 rounded-full whitespace-nowrap ml-2 shrink-0 ${
+              update.isStale
+                ? "bg-gray-100 text-gray-400"
+                : "bg-green-50 text-green-600"
+            }`}
+          >
+            {relativeTime(update.createdAt) ?? "—"}
+          </span>
+        </div>
+      ))}
+    </>
+  );
+}

--- a/lib/fresh-updates.test.ts
+++ b/lib/fresh-updates.test.ts
@@ -4,6 +4,7 @@ import {
   enrichFreshUpdatesWithStale,
   FRESH_UPDATE_STALE_THRESHOLD_MS,
   MAX_ITEM_NAME_LEN,
+  parseFreshUpdatePatchBody,
   parseFreshUpdatePostBody,
 } from "./fresh-updates";
 
@@ -106,5 +107,31 @@ describe("enrichFreshUpdatesWithStale", () => {
       out.map((u) => u.id),
       ["new", "old"],
     );
+  });
+});
+
+describe("parseFreshUpdatePatchBody", () => {
+  it("accepts item_name and description", () => {
+    const r = parseFreshUpdatePatchBody({
+      item_name: "  Bok Choy  ",
+      description: "  New crop  ",
+    });
+    assert.equal(r.ok, true);
+    if (r.ok) {
+      assert.equal(r.data.itemName, "Bok Choy");
+      assert.equal(r.data.note, "New crop");
+    }
+  });
+
+  it("requires at least one editable field", () => {
+    const r = parseFreshUpdatePatchBody({});
+    assert.equal(r.ok, false);
+    if (!r.ok) assert.match(r.error, /at least one/i);
+  });
+
+  it("rejects empty item_name", () => {
+    const r = parseFreshUpdatePatchBody({ item_name: "   " });
+    assert.equal(r.ok, false);
+    if (!r.ok) assert.match(r.error, /cannot be empty/i);
   });
 });

--- a/lib/fresh-updates.ts
+++ b/lib/fresh-updates.ts
@@ -19,6 +19,10 @@ export type ParsedFreshUpdatePost =
   | { ok: true; itemName: string; note: string | null }
   | { ok: false; error: string };
 
+export type ParsedFreshUpdatePatch =
+  | { ok: true; data: { itemName?: string; note?: string | null } }
+  | { ok: false; error: string };
+
 /**
  * Validates JSON body for POST /api/stores/:id/updates.
  */
@@ -61,6 +65,64 @@ export function parseFreshUpdatePostBody(body: unknown): ParsedFreshUpdatePost {
   }
 
   return { ok: true, itemName, note };
+}
+
+/**
+ * Validates JSON body for PATCH /api/stores/:id/posts/:postId.
+ * Supports either `note` or `description` as the optional text field.
+ */
+export function parseFreshUpdatePatchBody(
+  body: unknown,
+): ParsedFreshUpdatePatch {
+  if (body === null || typeof body !== "object") {
+    return { ok: false, error: "Request body must be a JSON object." };
+  }
+  const o = body as Record<string, unknown>;
+  const hasItemName = Object.prototype.hasOwnProperty.call(o, "item_name");
+  const hasNote = Object.prototype.hasOwnProperty.call(o, "note");
+  const hasDescription = Object.prototype.hasOwnProperty.call(o, "description");
+  if (!hasItemName && !hasNote && !hasDescription) {
+    return {
+      ok: false,
+      error: "Provide at least one of item_name, note, or description.",
+    };
+  }
+
+  const data: { itemName?: string; note?: string | null } = {};
+
+  if (hasItemName) {
+    if (typeof o.item_name !== "string") {
+      return { ok: false, error: "item_name must be a string." };
+    }
+    const itemName = o.item_name.trim();
+    if (!itemName) {
+      return { ok: false, error: "item_name cannot be empty." };
+    }
+    if (itemName.length > MAX_ITEM_NAME_LEN) {
+      return {
+        ok: false,
+        error: `item_name must be at most ${MAX_ITEM_NAME_LEN} characters.`,
+      };
+    }
+    data.itemName = itemName;
+  }
+
+  if (hasNote || hasDescription) {
+    const raw = hasNote ? o.note : o.description;
+    if (raw !== undefined && raw !== null && typeof raw !== "string") {
+      return { ok: false, error: "note/description must be a string when provided." };
+    }
+    const text = typeof raw === "string" ? raw.trim() : "";
+    if (text.length > MAX_NOTE_LEN) {
+      return {
+        ok: false,
+        error: `note/description must be at most ${MAX_NOTE_LEN} characters.`,
+      };
+    }
+    data.note = text.length > 0 ? text : null;
+  }
+
+  return { ok: true, data };
 }
 
 export function enrichFreshUpdatesWithStale<T extends { createdAt: Date }>(

--- a/lib/post-events.ts
+++ b/lib/post-events.ts
@@ -1,6 +1,6 @@
 import { EventEmitter } from "node:events";
 
-export type PostEventType = "POST_UPDATE" | "POST_DELETE";
+export type PostEventType = "POST_CREATE" | "POST_UPDATE" | "POST_DELETE";
 
 export type PostEventPayload = {
   storeId: string;

--- a/lib/post-events.ts
+++ b/lib/post-events.ts
@@ -1,0 +1,45 @@
+import { EventEmitter } from "node:events";
+
+export type PostEventType = "POST_UPDATE" | "POST_DELETE";
+
+export type PostEventPayload = {
+  storeId: string;
+  postId: string;
+  type: PostEventType;
+  occurredAt: string;
+};
+
+const POST_EVENTS_KEY = Symbol.for("grocerease.post-events.bus");
+
+type GlobalWithPostBus = typeof globalThis & {
+  [POST_EVENTS_KEY]?: EventEmitter;
+};
+
+function getPostEventBus() {
+  const g = globalThis as GlobalWithPostBus;
+  if (!g[POST_EVENTS_KEY]) {
+    const bus = new EventEmitter();
+    bus.setMaxListeners(0);
+    g[POST_EVENTS_KEY] = bus;
+  }
+  return g[POST_EVENTS_KEY];
+}
+
+export function broadcastPostEvent(event: Omit<PostEventPayload, "occurredAt">) {
+  const payload: PostEventPayload = {
+    ...event,
+    occurredAt: new Date().toISOString(),
+  };
+  getPostEventBus().emit(event.storeId, payload);
+}
+
+export function subscribeToPostEvents(
+  storeId: string,
+  listener: (payload: PostEventPayload) => void,
+) {
+  const bus = getPostEventBus();
+  bus.on(storeId, listener);
+  return () => {
+    bus.off(storeId, listener);
+  };
+}

--- a/scripts/deals-machine-tests.ts
+++ b/scripts/deals-machine-tests.ts
@@ -43,6 +43,23 @@ async function deleteDeal(
   return { res, json };
 }
 
+async function patchDeal(
+  storeId: string,
+  dealId: string,
+  body: unknown,
+  cookieHeader?: string,
+) {
+  const headers: Record<string, string> = { "Content-Type": "application/json" };
+  if (cookieHeader) headers.Cookie = cookieHeader;
+  const res = await fetch(`${BASE}/api/stores/${storeId}/deals/${dealId}`, {
+    method: "PATCH",
+    headers,
+    body: JSON.stringify(body),
+  });
+  const json = await res.json().catch(() => null);
+  return { res, json };
+}
+
 async function login() {
   const res = await fetch(`${BASE}/auth/login`, {
     method: "POST",
@@ -72,6 +89,45 @@ async function main() {
   assert.equal(valid.res.status, 201, "Valid POST /stores/:id/deals should return 201");
   const createdId = (valid.json as { deal?: { id?: string } })?.deal?.id;
   assert.ok(createdId, "Expected created deal id");
+
+  // 1a) PATCH edit existing deal => 200 and persisted
+  const updatedExpiryIso = new Date(Date.now() + 4 * 60 * 60 * 1000).toISOString();
+  const patchRes = await patchDeal(
+    STORE_ID,
+    createdId!,
+    {
+      price: 4.49,
+      description: "Machine criteria edited deal",
+      title: "Edited machine deal",
+      expires_at: updatedExpiryIso,
+    },
+    cookieHeader,
+  );
+  assert.equal(
+    patchRes.res.status,
+    200,
+    "PATCH /stores/:id/deals/:dealId should return 200",
+  );
+  const patchedDeal = (patchRes.json as { deal?: { price?: string; description?: string | null; title?: string; expiresAt?: string } })?.deal;
+  assert.equal(patchedDeal?.price, "4.49", "PATCH should update deal price");
+  assert.equal(
+    patchedDeal?.description,
+    "Machine criteria edited deal",
+    "PATCH should update deal description",
+  );
+  assert.equal(patchedDeal?.title, "Edited machine deal", "PATCH should update deal title");
+  assert.ok(
+    typeof patchedDeal?.expiresAt === "string" &&
+      new Date(patchedDeal.expiresAt).getTime() > Date.now(),
+    "PATCH should keep deal expiry in future",
+  );
+
+  const persistedPatched = await prisma.deal.findUnique({ where: { id: createdId! } });
+  assert.equal(
+    persistedPatched?.description,
+    "Machine criteria edited deal",
+    "PATCH should persist edited description",
+  );
 
   // 1b) POST source_deal_id valid => 201 with new id and timestamp
   const duplicateExpiry = new Date(Date.now() + 3 * 60 * 60 * 1000).toISOString();

--- a/scripts/fresh-updates-machine-tests.ts
+++ b/scripts/fresh-updates-machine-tests.ts
@@ -56,6 +56,41 @@ async function getJson(path: string, cookieHeader?: string) {
   return { res, json };
 }
 
+async function patchJson(path: string, body: unknown, cookieHeader?: string) {
+  const headers: Record<string, string> = { "Content-Type": "application/json" };
+  if (cookieHeader) headers.Cookie = cookieHeader;
+  const res = await fetch(`${BASE}${path}`, {
+    method: "PATCH",
+    headers,
+    body: JSON.stringify(body),
+  });
+  const text = await res.text();
+  let json: unknown = null;
+  try {
+    json = text ? (JSON.parse(text) as unknown) : null;
+  } catch {
+    json = text;
+  }
+  return { res, json };
+}
+
+async function deleteJson(path: string, cookieHeader?: string) {
+  const headers: Record<string, string> = {};
+  if (cookieHeader) headers.Cookie = cookieHeader;
+  const res = await fetch(`${BASE}${path}`, {
+    method: "DELETE",
+    headers,
+  });
+  const text = await res.text();
+  let json: unknown = null;
+  try {
+    json = text ? (JSON.parse(text) as unknown) : null;
+  } catch {
+    json = text;
+  }
+  return { res, json };
+}
+
 async function login(email: string) {
   const { res, setCookies } = await postJson("/auth/login", {
     email,
@@ -138,6 +173,50 @@ async function main() {
     assert.ok(row, "row should exist in DB");
     assert.equal(row!.storeId, lotusId);
     assert.equal(row!.itemName, uniqueName);
+  }
+
+  // PATCH ownership guard
+  {
+    const { res } = await patchJson(
+      `/api/stores/${lotusId}/posts/${createdId}`,
+      { item_name: "nope" },
+      crescentCookie,
+    );
+    assert.equal(res.status, 403, "non-owner PATCH should be 403");
+  }
+
+  // PATCH invalid body
+  {
+    const { res } = await patchJson(
+      `/api/stores/${lotusId}/posts/${createdId}`,
+      {},
+      lotusCookie,
+    );
+    assert.equal(res.status, 400, "PATCH without fields should be 400");
+  }
+
+  // PATCH success
+  const editedName = `${uniqueName} (Edited)`;
+  const editedNote = "Updated integration note";
+  {
+    const { res, json } = await patchJson(
+      `/api/stores/${lotusId}/posts/${createdId}`,
+      { item_name: editedName, description: editedNote },
+      lotusCookie,
+    );
+    assert.equal(res.status, 200, "owner PATCH should succeed");
+    const post = (json as {
+      post?: { id: string; itemName: string; note: string | null };
+    }).post;
+    assert.ok(post?.id === createdId, "PATCH response should include same id");
+    assert.equal(post?.itemName, editedName, "PATCH should update itemName");
+    assert.equal(post?.note, editedNote, "PATCH should update note");
+  }
+
+  {
+    const row = await prisma.freshUpdate.findUnique({ where: { id: createdId } });
+    assert.equal(row?.itemName, editedName, "DB should persist edited item name");
+    assert.equal(row?.note, editedNote, "DB should persist edited note");
   }
 
   // public GET: newest first and includes our row
@@ -230,6 +309,39 @@ async function main() {
       const b = new Date(updates[i]!.createdAt).getTime();
       assert.ok(a >= b, "owner list should stay newest-first");
     }
+  }
+
+  // DELETE ownership guard
+  {
+    const { res } = await deleteJson(
+      `/api/stores/${lotusId}/posts/${createdId}`,
+      crescentCookie,
+    );
+    assert.equal(res.status, 403, "non-owner DELETE should be 403");
+  }
+
+  // DELETE success (soft delete)
+  {
+    const { res } = await deleteJson(
+      `/api/stores/${lotusId}/posts/${createdId}`,
+      lotusCookie,
+    );
+    assert.equal(res.status, 200, "owner DELETE should succeed");
+  }
+
+  {
+    const row = await prisma.freshUpdate.findUnique({ where: { id: createdId } });
+    assert.ok(row?.deletedAt, "DELETE should soft-delete with deletedAt");
+  }
+
+  {
+    const { res, json } = await getJson(`/api/stores/${lotusId}/updates`);
+    assert.equal(res.status, 200);
+    const updates = (json as { updates: UpdateRow[] }).updates;
+    assert.ok(
+      !updates.some((u) => u.id === createdId),
+      "soft-deleted post should not appear in public list",
+    );
   }
 
   console.log("All fresh-updates machine tests passed.");


### PR DESCRIPTION
## Summary
- Add owner post management enhancements: `PATCH /api/stores/:id/posts/:postId` and soft-delete `DELETE /api/stores/:id/posts/:postId`, plus inline Edit/Delete controls in Manage Posts with delete confirmation.
- Add store-scoped real-time post events (`POST_UPDATE`, `POST_DELETE`) via SSE at `/api/stores/:id/posts/events`, and update shopper Fresh Today feed to refresh immediately on post changes.
- Add owner deal editing support with `PATCH /api/stores/:id/deals/:dealId` and inline edit UI for active deals in Manage Deals.
- Extend validation and automated coverage for post patch parsing, post patch/delete flows, and deal patch persistence.

## Test plan
- [x] `npm run lint` (passes; only pre-existing warnings in `scripts/signup-machine-tests.ts`)
- [x] `npm run test:fresh-updates`
- [x] `npm run test:deals-machine`
- [ ] Manual UI check: owner can edit/delete posts from `/dashboard/posts`
- [ ] Manual UI check: shopper store page updates without reload when post is edited/deleted
- [ ] Manual UI check: owner can edit active deals from `/dashboard/deals`