### PR TITLE
Feature/shopper activity inbox

### DIFF
--- a/app/(public)/login/LoginForm.tsx
+++ b/app/(public)/login/LoginForm.tsx
@@ -85,7 +85,7 @@ export default function LoginForm() {
           required
           value={email}
           onChange={(e) => setEmail(e.target.value)}
-          placeholder="you@yourstore.com"
+          placeholder="you@example.com"
           className="w-full px-3.5 py-2.5 rounded-md border-[1.5px] border-gray-200 text-[15px] text-gray-800 bg-white outline-none focus:border-green-400 transition-colors"
         />
       </div>
@@ -122,7 +122,7 @@ export default function LoginForm() {
         disabled={pending}
         className="w-full py-3 rounded-md text-[15px] font-semibold text-white bg-green-600 hover:bg-green-800 transition-colors mt-1 disabled:opacity-60"
       >
-        {pending ? "Signing in…" : "Sign in to dashboard"}
+        {pending ? "Signing in…" : "Sign in"}
       </button>
     </form>
   );

--- a/app/(public)/my-alerts/MyAlertsClient.tsx
+++ b/app/(public)/my-alerts/MyAlertsClient.tsx
@@ -1,0 +1,141 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+
+type AlertRow = {
+  id: string;
+  type: string;
+  storeId: string | null;
+  itemId: string | null;
+  createdAt: string;
+  store: { id: string; name: string } | null;
+  item: { id: string; name: string } | null;
+};
+
+export default function MyAlertsClient() {
+  const [alerts, setAlerts] = useState<AlertRow[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    setError(null);
+    const res = await fetch("/api/alerts", { credentials: "include" });
+    if (!res.ok) {
+      let msg = "Could not load alerts.";
+      try {
+        const d = (await res.json()) as { error?: string };
+        if (d.error) msg = d.error;
+      } catch {
+        /* ignore */
+      }
+      setError(msg);
+      setAlerts([]);
+      return;
+    }
+    const data = (await res.json()) as { alerts?: AlertRow[] };
+    setAlerts(Array.isArray(data.alerts) ? data.alerts : []);
+  }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      await load();
+      if (!cancelled) setLoading(false);
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [load]);
+
+  async function unsubscribe(alert: AlertRow) {
+    const previous = alerts;
+    setAlerts((list) => list.filter((a) => a.id !== alert.id));
+    setError(null);
+    const res = await fetch(`/api/alerts/${alert.id}`, {
+      method: "DELETE",
+      credentials: "include",
+    });
+    if (!res.ok) {
+      setAlerts(previous);
+      setError("Could not turn off that alert. Try again.");
+    }
+  }
+
+  if (loading) {
+    return <p className="text-[14px] text-gray-400">Loading your alerts…</p>;
+  }
+
+  if (error && alerts.length === 0) {
+    return (
+      <p className="text-[14px] text-red-700 bg-red-50 border border-red-100 rounded-lg px-3 py-2">
+        {error}
+      </p>
+    );
+  }
+
+  if (alerts.length === 0) {
+    return (
+      <div className="text-center py-12 px-4 rounded-2xl border border-dashed border-gray-200 bg-gray-50">
+        <div className="text-[40px] mb-2">🔔</div>
+        <p className="text-[15px] text-gray-700 font-medium mb-1">
+          No active alerts
+        </p>
+        <p className="text-[13px] text-gray-500 max-w-[280px] mx-auto">
+          Follow a store or turn on item notifications from a store page.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-3">
+      {error && (
+        <p className="text-[13px] text-red-700 bg-red-50 border border-red-100 rounded-lg px-3 py-2">
+          {error}
+        </p>
+      )}
+      <ul className="space-y-2">
+        {alerts.map((a) => (
+          <li
+            key={a.id}
+            className="flex flex-col sm:flex-row sm:items-center gap-3 p-4 rounded-xl border border-gray-200 bg-white"
+          >
+            <div className="flex-1 min-w-0">
+              <div className="flex items-center gap-2 flex-wrap">
+                <span className="text-[11px] font-bold uppercase tracking-wide text-green-700 bg-green-50 px-2 py-0.5 rounded-full">
+                  Active
+                </span>
+                <span className="text-[11px] font-medium text-gray-500 uppercase">
+                  {a.type === "store_follow" ? "Store" : "Item restock"}
+                </span>
+              </div>
+              <p className="text-[15px] font-semibold text-gray-800 mt-1">
+                {a.type === "store_follow"
+                  ? a.store?.name ?? "Store"
+                  : a.item?.name ?? "Item"}
+              </p>
+              <p className="text-[13px] text-gray-500 mt-0.5">
+                {a.type === "item_restock" && a.store?.name
+                  ? `${a.store.name} · `
+                  : null}
+                Subscribed{" "}
+                {new Date(a.createdAt).toLocaleDateString("en-US", {
+                  month: "short",
+                  day: "numeric",
+                  year: "numeric",
+                })}
+              </p>
+            </div>
+            <button
+              type="button"
+              onClick={() => unsubscribe(a)}
+              className="shrink-0 px-3 py-2 rounded-lg text-[13px] font-medium border border-gray-200 text-gray-600 hover:bg-red-50 hover:text-red-800 hover:border-red-100 transition-colors"
+            >
+              Turn off
+            </button>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/app/(public)/my-alerts/MyAlertsClient.tsx
+++ b/app/(public)/my-alerts/MyAlertsClient.tsx
@@ -23,10 +23,13 @@ type NotificationRow = {
   store: { id: string; name: string };
 };
 
+const KIND_LABELS: Record<string, string> = {
+  store_fresh_update: "Fresh update",
+  store_new_deal: "New deal",
+};
+
 function kindLabel(kind: string): string {
-  if (kind === "store_fresh_update") return "Fresh update";
-  if (kind === "store_new_deal") return "New deal";
-  return kind;
+  return KIND_LABELS[kind] ?? kind;
 }
 
 function byCreatedDesc(a: NotificationRow, b: NotificationRow): number {
@@ -106,14 +109,20 @@ function InboxNotificationRow({
 export default function MyAlertsClient() {
   const [alerts, setAlerts] = useState<AlertRow[]>([]);
   const [notifications, setNotifications] = useState<NotificationRow[]>([]);
+  const [inboxHasMore, setInboxHasMore] = useState(false);
+  const [inboxLoadingMore, setInboxLoadingMore] = useState(false);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [inboxError, setInboxError] = useState<string | null>(null);
 
   const load = useCallback(async () => {
     setError(null);
+    setInboxError(null);
     const [aRes, nRes] = await Promise.all([
       fetch("/api/alerts", { credentials: "include" }),
-      fetch("/api/shopper/notifications", { credentials: "include" }),
+      fetch("/api/shopper/notifications?skip=0&take=50", {
+        credentials: "include",
+      }),
     ]);
 
     if (!aRes.ok) {
@@ -132,10 +141,23 @@ export default function MyAlertsClient() {
     }
 
     if (nRes.ok) {
-      const nd = (await nRes.json()) as { notifications?: NotificationRow[] };
+      const nd = (await nRes.json()) as {
+        notifications?: NotificationRow[];
+        hasMore?: boolean;
+      };
       setNotifications(Array.isArray(nd.notifications) ? nd.notifications : []);
+      setInboxHasMore(Boolean(nd.hasMore));
     } else {
+      let msg = "Could not load activity.";
+      try {
+        const d = (await nRes.json()) as { error?: string };
+        if (d.error) msg = d.error;
+      } catch {
+        /* ignore */
+      }
+      setInboxError(msg);
       setNotifications([]);
+      setInboxHasMore(false);
     }
   }, []);
 
@@ -165,19 +187,53 @@ export default function MyAlertsClient() {
   }
 
   async function markNotificationRead(id: string, read: boolean) {
+    setInboxError(null);
     const res = await fetch(`/api/shopper/notifications/${id}`, {
       method: "PATCH",
       credentials: "include",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ read }),
     });
-    if (!res.ok) return;
+    if (!res.ok) {
+      setInboxError("Could not update read status. Try again.");
+      return;
+    }
     const data = (await res.json()) as { readAt?: string | null };
     setNotifications((list) =>
       list.map((n) =>
         n.id === id ? { ...n, readAt: data.readAt ?? null } : n,
       ),
     );
+  }
+
+  async function loadMoreInbox() {
+    if (!inboxHasMore || inboxLoadingMore) return;
+    setInboxError(null);
+    setInboxLoadingMore(true);
+    try {
+      const skip = notifications.length;
+      const res = await fetch(
+        `/api/shopper/notifications?skip=${skip}&take=50`,
+        { credentials: "include" },
+      );
+      if (!res.ok) {
+        setInboxError("Could not load more activity.");
+        return;
+      }
+      const data = (await res.json()) as {
+        notifications?: NotificationRow[];
+        hasMore?: boolean;
+      };
+      const more = Array.isArray(data.notifications) ? data.notifications : [];
+      setNotifications((prev) => {
+        const seen = new Set(prev.map((n) => n.id));
+        const merged = more.filter((n) => !seen.has(n.id));
+        return [...prev, ...merged];
+      });
+      setInboxHasMore(Boolean(data.hasMore));
+    } finally {
+      setInboxLoadingMore(false);
+    }
   }
 
   const { inboxUnread, inboxRead } = useMemo(() => {
@@ -214,14 +270,26 @@ export default function MyAlertsClient() {
           ) : null}
         </div>
 
+        {inboxError ? (
+          <p
+            className="text-[13px] text-red-700 bg-red-50 border border-red-100 rounded-lg px-3 py-2 mb-3"
+            role="alert"
+          >
+            {inboxError}
+          </p>
+        ) : null}
+
         {notifications.length === 0 ? (
-          <div className="rounded-2xl border border-dashed border-gray-200 bg-gray-50/80 px-4 py-10 text-center">
-            <p className="text-[14px] text-gray-600 mb-1">No activity yet</p>
-            <p className="text-[13px] text-gray-500 max-w-[320px] mx-auto">
-              When a store you follow posts in <strong className="text-gray-700">Fresh today</strong>{" "}
-              or adds a deal, it will show up here.
-            </p>
-          </div>
+          inboxError ? null : (
+            <div className="rounded-2xl border border-dashed border-gray-200 bg-gray-50/80 px-4 py-10 text-center">
+              <p className="text-[14px] text-gray-600 mb-1">No activity yet</p>
+              <p className="text-[13px] text-gray-500 max-w-[320px] mx-auto">
+                When a store you follow posts in{" "}
+                <strong className="text-gray-700">Fresh today</strong> or adds a deal, it will show
+                up here.
+              </p>
+            </div>
+          )
         ) : (
           <ul className="space-y-2">
             {inboxUnread.map((n) => (
@@ -248,6 +316,19 @@ export default function MyAlertsClient() {
             ))}
           </ul>
         )}
+
+        {notifications.length > 0 && inboxHasMore ? (
+          <div className="mt-3">
+            <button
+              type="button"
+              onClick={() => void loadMoreInbox()}
+              disabled={inboxLoadingMore}
+              className="text-[13px] font-medium text-green-700 hover:text-green-900 disabled:opacity-50"
+            >
+              {inboxLoadingMore ? "Loading…" : "Load older activity"}
+            </button>
+          </div>
+        ) : null}
       </section>
 
       <section aria-labelledby="subscriptions-heading">

--- a/app/(public)/my-alerts/MyAlertsClient.tsx
+++ b/app/(public)/my-alerts/MyAlertsClient.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { useCallback, useEffect, useState } from "react";
+import Link from "next/link";
+import { useCallback, useEffect, useMemo, useState } from "react";
 
 type AlertRow = {
   id: string;
@@ -12,28 +13,130 @@ type AlertRow = {
   item: { id: string; name: string } | null;
 };
 
+type NotificationRow = {
+  id: string;
+  kind: string;
+  title: string;
+  body: string | null;
+  readAt: string | null;
+  createdAt: string;
+  store: { id: string; name: string };
+};
+
+function kindLabel(kind: string): string {
+  if (kind === "store_fresh_update") return "Fresh update";
+  if (kind === "store_new_deal") return "New deal";
+  return kind;
+}
+
+function byCreatedDesc(a: NotificationRow, b: NotificationRow): number {
+  return new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime();
+}
+
+function InboxNotificationRow({
+  n,
+  markNotificationRead,
+}: {
+  n: NotificationRow;
+  markNotificationRead: (id: string, read: boolean) => void | Promise<void>;
+}) {
+  const unread = !n.readAt;
+  return (
+    <li
+      className={`rounded-xl border px-4 py-3 transition-colors duration-200 ${
+        unread
+          ? "border-green-200 bg-green-50/50 shadow-sm"
+          : "border-gray-200 bg-white"
+      }`}
+    >
+      <div className="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-3">
+        <div className="min-w-0">
+          <div className="flex items-center gap-2 flex-wrap">
+            <span className="text-[11px] font-bold uppercase tracking-wide text-green-800 bg-green-100/80 px-2 py-0.5 rounded-full">
+              {kindLabel(n.kind)}
+            </span>
+            {!unread ? (
+              <span className="text-[11px] text-gray-400">Read</span>
+            ) : null}
+          </div>
+          <p className="text-[15px] font-semibold text-gray-900 mt-1.5">{n.title}</p>
+          {n.body ? (
+            <p className="text-[13px] text-gray-600 mt-0.5">{n.body}</p>
+          ) : null}
+          <p className="text-[12px] text-gray-400 mt-2">
+            {n.store.name} ·{" "}
+            {new Date(n.createdAt).toLocaleString("en-US", {
+              month: "short",
+              day: "numeric",
+              hour: "numeric",
+              minute: "2-digit",
+            })}
+          </p>
+        </div>
+        <div className="flex flex-wrap gap-2 shrink-0">
+          <Link
+            href={`/stores/${n.store.id}`}
+            className="inline-flex justify-center items-center px-3 py-1.5 rounded-lg text-[12px] font-semibold bg-green-600 text-white hover:bg-green-800 transition-colors"
+          >
+            View store
+          </Link>
+          {unread ? (
+            <button
+              type="button"
+              onClick={() => markNotificationRead(n.id, true)}
+              className="px-3 py-1.5 rounded-lg text-[12px] font-medium border border-gray-200 text-gray-600 hover:bg-gray-50 transition-colors"
+            >
+              Mark read
+            </button>
+          ) : (
+            <button
+              type="button"
+              onClick={() => markNotificationRead(n.id, false)}
+              className="px-3 py-1.5 rounded-lg text-[12px] font-medium border border-gray-200 text-gray-500 hover:bg-gray-50 transition-colors"
+            >
+              Mark unread
+            </button>
+          )}
+        </div>
+      </div>
+    </li>
+  );
+}
+
 export default function MyAlertsClient() {
   const [alerts, setAlerts] = useState<AlertRow[]>([]);
+  const [notifications, setNotifications] = useState<NotificationRow[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
   const load = useCallback(async () => {
     setError(null);
-    const res = await fetch("/api/alerts", { credentials: "include" });
-    if (!res.ok) {
-      let msg = "Could not load alerts.";
+    const [aRes, nRes] = await Promise.all([
+      fetch("/api/alerts", { credentials: "include" }),
+      fetch("/api/shopper/notifications", { credentials: "include" }),
+    ]);
+
+    if (!aRes.ok) {
+      let msg = "Could not load subscriptions.";
       try {
-        const d = (await res.json()) as { error?: string };
+        const d = (await aRes.json()) as { error?: string };
         if (d.error) msg = d.error;
       } catch {
         /* ignore */
       }
       setError(msg);
       setAlerts([]);
-      return;
+    } else {
+      const data = (await aRes.json()) as { alerts?: AlertRow[] };
+      setAlerts(Array.isArray(data.alerts) ? data.alerts : []);
     }
-    const data = (await res.json()) as { alerts?: AlertRow[] };
-    setAlerts(Array.isArray(data.alerts) ? data.alerts : []);
+
+    if (nRes.ok) {
+      const nd = (await nRes.json()) as { notifications?: NotificationRow[] };
+      setNotifications(Array.isArray(nd.notifications) ? nd.notifications : []);
+    } else {
+      setNotifications([]);
+    }
   }, []);
 
   useEffect(() => {
@@ -61,81 +164,169 @@ export default function MyAlertsClient() {
     }
   }
 
+  async function markNotificationRead(id: string, read: boolean) {
+    const res = await fetch(`/api/shopper/notifications/${id}`, {
+      method: "PATCH",
+      credentials: "include",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ read }),
+    });
+    if (!res.ok) return;
+    const data = (await res.json()) as { readAt?: string | null };
+    setNotifications((list) =>
+      list.map((n) =>
+        n.id === id ? { ...n, readAt: data.readAt ?? null } : n,
+      ),
+    );
+  }
+
+  const { inboxUnread, inboxRead } = useMemo(() => {
+    const unread = notifications.filter((n) => !n.readAt).sort(byCreatedDesc);
+    const read = notifications.filter((n) => n.readAt).sort(byCreatedDesc);
+    return { inboxUnread: unread, inboxRead: read };
+  }, [notifications]);
+
   if (loading) {
-    return <p className="text-[14px] text-gray-400">Loading your alerts…</p>;
+    return <p className="text-[14px] text-gray-400">Loading…</p>;
   }
 
-  if (error && alerts.length === 0) {
-    return (
-      <p className="text-[14px] text-red-700 bg-red-50 border border-red-100 rounded-lg px-3 py-2">
-        {error}
-      </p>
-    );
-  }
-
-  if (alerts.length === 0) {
-    return (
-      <div className="text-center py-12 px-4 rounded-2xl border border-dashed border-gray-200 bg-gray-50">
-        <div className="text-[40px] mb-2">🔔</div>
-        <p className="text-[15px] text-gray-700 font-medium mb-1">
-          No active alerts
-        </p>
-        <p className="text-[13px] text-gray-500 max-w-[280px] mx-auto">
-          Follow a store or turn on item notifications from a store page.
-        </p>
-      </div>
-    );
-  }
+  const unreadCount = notifications.filter((n) => !n.readAt).length;
 
   return (
-    <div className="space-y-3">
-      {error && (
-        <p className="text-[13px] text-red-700 bg-red-50 border border-red-100 rounded-lg px-3 py-2">
-          {error}
-        </p>
-      )}
-      <ul className="space-y-2">
-        {alerts.map((a) => (
-          <li
-            key={a.id}
-            className="flex flex-col sm:flex-row sm:items-center gap-3 p-4 rounded-xl border border-gray-200 bg-white"
-          >
-            <div className="flex-1 min-w-0">
-              <div className="flex items-center gap-2 flex-wrap">
-                <span className="text-[11px] font-bold uppercase tracking-wide text-green-700 bg-green-50 px-2 py-0.5 rounded-full">
-                  Active
-                </span>
-                <span className="text-[11px] font-medium text-gray-500 uppercase">
-                  {a.type === "store_follow" ? "Store" : "Item restock"}
-                </span>
-              </div>
-              <p className="text-[15px] font-semibold text-gray-800 mt-1">
-                {a.type === "store_follow"
-                  ? a.store?.name ?? "Store"
-                  : a.item?.name ?? "Item"}
-              </p>
-              <p className="text-[13px] text-gray-500 mt-0.5">
-                {a.type === "item_restock" && a.store?.name
-                  ? `${a.store.name} · `
-                  : null}
-                Subscribed{" "}
-                {new Date(a.createdAt).toLocaleDateString("en-US", {
-                  month: "short",
-                  day: "numeric",
-                  year: "numeric",
-                })}
-              </p>
-            </div>
-            <button
-              type="button"
-              onClick={() => unsubscribe(a)}
-              className="shrink-0 px-3 py-2 rounded-lg text-[13px] font-medium border border-gray-200 text-gray-600 hover:bg-red-50 hover:text-red-800 hover:border-red-100 transition-colors"
+    <div className="space-y-10">
+      <section aria-labelledby="activity-heading">
+        <div className="flex flex-col sm:flex-row sm:items-end sm:justify-between gap-2 mb-4">
+          <div>
+            <h2
+              id="activity-heading"
+              className="font-display text-[20px] font-semibold text-gray-800"
             >
-              Turn off
-            </button>
-          </li>
-        ))}
-      </ul>
+              Activity
+            </h2>
+            <p className="text-[13px] text-gray-500 mt-0.5">
+              Updates from stores you follow (new posts and deals).
+            </p>
+          </div>
+          {unreadCount > 0 ? (
+            <span className="text-[12px] font-medium text-green-800 bg-green-50 px-2.5 py-1 rounded-full w-fit">
+              {unreadCount} unread
+            </span>
+          ) : null}
+        </div>
+
+        {notifications.length === 0 ? (
+          <div className="rounded-2xl border border-dashed border-gray-200 bg-gray-50/80 px-4 py-10 text-center">
+            <p className="text-[14px] text-gray-600 mb-1">No activity yet</p>
+            <p className="text-[13px] text-gray-500 max-w-[320px] mx-auto">
+              When a store you follow posts in <strong className="text-gray-700">Fresh today</strong>{" "}
+              or adds a deal, it will show up here.
+            </p>
+          </div>
+        ) : (
+          <ul className="space-y-2">
+            {inboxUnread.map((n) => (
+              <InboxNotificationRow
+                key={n.id}
+                n={n}
+                markNotificationRead={markNotificationRead}
+              />
+            ))}
+            {inboxRead.length > 0 && inboxUnread.length > 0 ? (
+              <li
+                className="list-none pt-4 pb-0.5 text-[11px] font-semibold uppercase tracking-wide text-gray-400 px-1"
+                aria-hidden
+              >
+                Read
+              </li>
+            ) : null}
+            {inboxRead.map((n) => (
+              <InboxNotificationRow
+                key={n.id}
+                n={n}
+                markNotificationRead={markNotificationRead}
+              />
+            ))}
+          </ul>
+        )}
+      </section>
+
+      <section aria-labelledby="subscriptions-heading">
+        <h2
+          id="subscriptions-heading"
+          className="font-display text-[20px] font-semibold text-gray-800 mb-1"
+        >
+          Subscriptions
+        </h2>
+        <p className="text-[13px] text-gray-500 mb-4">
+          Turn off an alert to stop following that store or item.
+        </p>
+
+        {error && alerts.length === 0 && notifications.length === 0 ? (
+          <p className="text-[14px] text-red-700 bg-red-50 border border-red-100 rounded-lg px-3 py-2">
+            {error}
+          </p>
+        ) : null}
+
+        {alerts.length === 0 ? (
+          <div className="text-center py-10 px-4 rounded-2xl border border-dashed border-gray-200 bg-gray-50">
+            <div className="text-[36px] mb-2">🔔</div>
+            <p className="text-[15px] text-gray-700 font-medium mb-1">
+              No active subscriptions
+            </p>
+            <p className="text-[13px] text-gray-500 max-w-[280px] mx-auto">
+              Follow a store or turn on item notifications from a store page.
+            </p>
+          </div>
+        ) : (
+          <ul className="space-y-2">
+            {error ? (
+              <p className="text-[13px] text-red-700 bg-red-50 border border-red-100 rounded-lg px-3 py-2">
+                {error}
+              </p>
+            ) : null}
+            {alerts.map((a) => (
+              <li
+                key={a.id}
+                className="flex flex-col sm:flex-row sm:items-center gap-3 p-4 rounded-xl border border-gray-200 bg-white"
+              >
+                <div className="flex-1 min-w-0">
+                  <div className="flex items-center gap-2 flex-wrap">
+                    <span className="text-[11px] font-bold uppercase tracking-wide text-green-700 bg-green-50 px-2 py-0.5 rounded-full">
+                      Active
+                    </span>
+                    <span className="text-[11px] font-medium text-gray-500 uppercase">
+                      {a.type === "store_follow" ? "Store" : "Item restock"}
+                    </span>
+                  </div>
+                  <p className="text-[15px] font-semibold text-gray-800 mt-1">
+                    {a.type === "store_follow"
+                      ? a.store?.name ?? "Store"
+                      : a.item?.name ?? "Item"}
+                  </p>
+                  <p className="text-[13px] text-gray-500 mt-0.5">
+                    {a.type === "item_restock" && a.store?.name
+                      ? `${a.store.name} · `
+                      : null}
+                    Subscribed{" "}
+                    {new Date(a.createdAt).toLocaleDateString("en-US", {
+                      month: "short",
+                      day: "numeric",
+                      year: "numeric",
+                    })}
+                  </p>
+                </div>
+                <button
+                  type="button"
+                  onClick={() => unsubscribe(a)}
+                  className="shrink-0 px-3 py-2 rounded-lg text-[13px] font-medium border border-gray-200 text-gray-600 hover:bg-red-50 hover:text-red-800 hover:border-red-100 transition-colors"
+                >
+                  Turn off
+                </button>
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
     </div>
   );
 }

--- a/app/(public)/my-alerts/page.tsx
+++ b/app/(public)/my-alerts/page.tsx
@@ -26,8 +26,7 @@ export default async function MyAlertsPage() {
         My alerts
       </h1>
       <p className="text-[14px] text-gray-500 mb-8">
-        Active subscriptions for deals and restocks. Turn off any alert below
-        to unsubscribe.
+        See what stores you follow have posted, and manage your subscriptions.
       </p>
       <MyAlertsClient />
     </div>

--- a/app/(public)/my-alerts/page.tsx
+++ b/app/(public)/my-alerts/page.tsx
@@ -1,0 +1,35 @@
+import { redirect } from "next/navigation";
+import Link from "next/link";
+import { auth } from "@/auth";
+import MyAlertsClient from "./MyAlertsClient";
+
+export default async function MyAlertsPage() {
+  const session = await auth();
+  if (!session?.user) {
+    redirect(`/login?callbackUrl=${encodeURIComponent("/my-alerts")}`);
+  }
+  if (session.role !== "shopper") {
+    redirect("/dashboard");
+  }
+
+  return (
+    <div className="max-w-[640px] mx-auto px-4 sm:px-6 lg:px-8 py-8">
+      <div className="mb-6">
+        <Link
+          href="/"
+          className="text-[13px] text-green-600 hover:underline"
+        >
+          ← Discover stores
+        </Link>
+      </div>
+      <h1 className="font-display text-[26px] font-semibold text-gray-800 mb-1">
+        My alerts
+      </h1>
+      <p className="text-[14px] text-gray-500 mb-8">
+        Active subscriptions for deals and restocks. Turn off any alert below
+        to unsubscribe.
+      </p>
+      <MyAlertsClient />
+    </div>
+  );
+}

--- a/app/(public)/signup/page.tsx
+++ b/app/(public)/signup/page.tsx
@@ -7,6 +7,9 @@ import SignupForm from "./SignupForm";
 export default async function SignupPage() {
   const session = await auth();
   if (session?.user) {
+    if (session.role === "shopper") {
+      redirect("/");
+    }
     redirect("/dashboard");
   }
 

--- a/app/(public)/signup/shopper/ShopperSignupForm.tsx
+++ b/app/(public)/signup/shopper/ShopperSignupForm.tsx
@@ -1,0 +1,219 @@
+"use client";
+
+import Link from "next/link";
+import { useRouter, useSearchParams } from "next/navigation";
+import { useState } from "react";
+import {
+  isSafeRelativeAppPath,
+  safeCallbackPath,
+} from "@/lib/safe-callback-path";
+
+interface SignupApiResponse {
+  ok?: boolean;
+  redirectUrl?: string;
+  error?: string;
+  fieldErrors?: Record<string, string>;
+  user?: unknown;
+}
+
+export default function ShopperSignupForm() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const callbackUrl = safeCallbackPath(searchParams.get("callbackUrl"), "/");
+
+  const [name, setName] = useState("");
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [confirmPassword, setConfirmPassword] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [fieldErrors, setFieldErrors] = useState<Record<string, string>>({});
+  const [pending, setPending] = useState(false);
+
+  async function onSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setError(null);
+    setFieldErrors({});
+    setPending(true);
+    try {
+      const res = await fetch("/auth/signup-shopper", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        credentials: "include",
+        body: JSON.stringify({
+          name,
+          email,
+          password,
+          confirmPassword,
+          callbackUrl,
+        }),
+      });
+      const data = (await res.json().catch(() => ({}))) as SignupApiResponse;
+
+      if (res.status === 400) {
+        const fe = data.fieldErrors;
+        if (fe && typeof fe === "object") {
+          setFieldErrors(fe);
+        }
+        setError(
+          typeof data.error === "string"
+            ? data.error
+            : "Please fix the errors below."
+        );
+        return;
+      }
+
+      if (res.status === 409) {
+        setError(
+          typeof data.error === "string"
+            ? data.error
+            : "This email is already registered."
+        );
+        return;
+      }
+
+      if (res.status === 201 && data.ok) {
+        const url = data.redirectUrl;
+        if (typeof url === "string" && isSafeRelativeAppPath(url)) {
+          router.push(url);
+          router.refresh();
+          return;
+        }
+      }
+
+      if (res.status === 201 && data.user) {
+        setError(
+          typeof data.error === "string"
+            ? data.error
+            : "Account created. Please sign in."
+        );
+        router.push(`/login?callbackUrl=${encodeURIComponent(callbackUrl)}`);
+        router.refresh();
+        return;
+      }
+
+      setError("Something went wrong. Try again.");
+    } finally {
+      setPending(false);
+    }
+  }
+
+  return (
+    <form onSubmit={onSubmit} className="space-y-4">
+      {error && (
+        <div
+          role="alert"
+          className="rounded-md border border-red-200 bg-red-50 px-3 py-2 text-[13px] text-red-800"
+        >
+          {error}
+        </div>
+      )}
+
+      <div>
+        <label
+          htmlFor="shopper-signup-name"
+          className="block text-[13px] font-medium text-gray-600 mb-1.5"
+        >
+          Your name
+        </label>
+        <input
+          id="shopper-signup-name"
+          type="text"
+          autoComplete="name"
+          required
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          placeholder="e.g. Nina Martinez"
+          className="w-full px-3.5 py-2.5 rounded-md border-[1.5px] border-gray-200 text-[15px] text-gray-800 bg-white outline-none focus:border-green-400 transition-colors"
+        />
+        {fieldErrors.name && (
+          <p className="text-[12px] text-red-600 mt-1">{fieldErrors.name}</p>
+        )}
+      </div>
+
+      <div>
+        <label
+          htmlFor="shopper-signup-email"
+          className="block text-[13px] font-medium text-gray-600 mb-1.5"
+        >
+          Email address
+        </label>
+        <input
+          id="shopper-signup-email"
+          type="email"
+          autoComplete="email"
+          required
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          placeholder="you@example.com"
+          className="w-full px-3.5 py-2.5 rounded-md border-[1.5px] border-gray-200 text-[15px] text-gray-800 bg-white outline-none focus:border-green-400 transition-colors"
+        />
+        {fieldErrors.email && (
+          <p className="text-[12px] text-red-600 mt-1">{fieldErrors.email}</p>
+        )}
+      </div>
+
+      <div>
+        <label
+          htmlFor="shopper-signup-password"
+          className="block text-[13px] font-medium text-gray-600 mb-1.5"
+        >
+          Password
+        </label>
+        <input
+          id="shopper-signup-password"
+          type="password"
+          autoComplete="new-password"
+          required
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+          placeholder="At least 8 characters, with a letter and a number"
+          className="w-full px-3.5 py-2.5 rounded-md border-[1.5px] border-gray-200 text-[15px] text-gray-800 bg-white outline-none focus:border-green-400 transition-colors"
+        />
+        {fieldErrors.password && (
+          <p className="text-[12px] text-red-600 mt-1">{fieldErrors.password}</p>
+        )}
+      </div>
+
+      <div>
+        <label
+          htmlFor="shopper-signup-confirm"
+          className="block text-[13px] font-medium text-gray-600 mb-1.5"
+        >
+          Confirm password
+        </label>
+        <input
+          id="shopper-signup-confirm"
+          type="password"
+          autoComplete="new-password"
+          required
+          value={confirmPassword}
+          onChange={(e) => setConfirmPassword(e.target.value)}
+          className="w-full px-3.5 py-2.5 rounded-md border-[1.5px] border-gray-200 text-[15px] text-gray-800 bg-white outline-none focus:border-green-400 transition-colors"
+        />
+        {fieldErrors.confirmPassword && (
+          <p className="text-[12px] text-red-600 mt-1">
+            {fieldErrors.confirmPassword}
+          </p>
+        )}
+      </div>
+
+      <button
+        type="submit"
+        disabled={pending}
+        className="w-full py-3 rounded-md text-[15px] font-semibold text-white bg-green-600 hover:bg-green-800 transition-colors mt-1 disabled:opacity-60"
+      >
+        {pending ? "Creating account…" : "Create shopper account"}
+      </button>
+
+      <p className="text-center text-[13px] text-gray-500">
+        Already have an account?{" "}
+        <Link
+          href={`/login?callbackUrl=${encodeURIComponent(callbackUrl)}`}
+          className="text-green-600 font-medium hover:text-green-800"
+        >
+          Sign in
+        </Link>
+      </p>
+    </form>
+  );
+}

--- a/app/(public)/signup/shopper/page.tsx
+++ b/app/(public)/signup/shopper/page.tsx
@@ -3,9 +3,9 @@ import Link from "next/link";
 import { redirect } from "next/navigation";
 import { auth } from "@/auth";
 import { safeCallbackPath } from "@/lib/safe-callback-path";
-import LoginForm from "./LoginForm";
+import ShopperSignupForm from "./ShopperSignupForm";
 
-export default async function LoginPage({
+export default async function ShopperSignupPage({
   searchParams,
 }: {
   searchParams: Promise<{ callbackUrl?: string }>;
@@ -26,27 +26,24 @@ export default async function LoginPage({
           LocalGrocer
         </div>
         <p className="text-[14px] text-gray-400 mb-7">
-          Sign in as a store owner or a shopper
+          Create a free shopper account for deal and restock alerts
         </p>
 
         <Suspense fallback={<div className="text-sm text-gray-500">Loading…</div>}>
-          <LoginForm />
+          <ShopperSignupForm />
         </Suspense>
 
         <hr className="border-gray-100 my-5" />
 
         <p className="text-center text-[13px] text-gray-400">
-          New store owner?{" "}
+          Run a store?{" "}
           <Link href="/signup" className="text-green-600">
-            Create an owner account
+            Owner signup
           </Link>
-          <br />
-          <span className="inline-block mt-2">
-            Shopper?{" "}
-            <Link href="/signup/shopper" className="text-green-600">
-              Free shopper signup
-            </Link>
-          </span>
+          {" · "}
+          <Link href="/" className="text-green-600">
+            Home
+          </Link>
         </p>
       </div>
     </div>

--- a/app/(public)/stores/[id]/page.tsx
+++ b/app/(public)/stores/[id]/page.tsx
@@ -60,6 +60,7 @@ export default async function StoreProfilePage({
     rawRole === "shopper" || rawRole === "owner" ? rawRole : null;
 
   let initialStoreFollow = false;
+  let storeFollowAlertId: string | null = null;
   if (session?.role === "shopper") {
     const follow = await prisma.alert.findFirst({
       where: {
@@ -71,6 +72,7 @@ export default async function StoreProfilePage({
       select: { id: true },
     });
     initialStoreFollow = Boolean(follow);
+    storeFollowAlertId = follow?.id ?? null;
   }
 
   const freshUpdatesDisplay = enrichFreshUpdatesWithStale(
@@ -176,6 +178,7 @@ export default async function StoreProfilePage({
             storeId={store.id}
             storeName={store.name}
             initialSubscribed={initialStoreFollow}
+            initialStoreFollowAlertId={storeFollowAlertId}
             viewerRole={viewerRole}
           />
         </section>

--- a/app/(public)/stores/[id]/page.tsx
+++ b/app/(public)/stores/[id]/page.tsx
@@ -55,6 +55,10 @@ export default async function StoreProfilePage({
   if (!store || !store.isPublished) notFound();
 
   const session = await auth();
+  const rawRole = session?.user ? session.role : null;
+  const viewerRole =
+    rawRole === "shopper" || rawRole === "owner" ? rawRole : null;
+
   let initialStoreFollow = false;
   if (session?.role === "shopper") {
     const follow = await prisma.alert.findFirst({
@@ -129,18 +133,59 @@ export default async function StoreProfilePage({
         </div>
       </div>
 
-      <div className="mb-4">
-        <StoreAlertSubscribe
-          storeId={store.id}
-          storeName={store.name}
-          initialSubscribed={initialStoreFollow}
-        />
-      </div>
+      {viewerRole === "owner" ? (
+        <div className="mb-4 rounded-xl border border-gray-100 bg-gray-50 px-4 py-3 text-[13px] text-gray-600 leading-relaxed">
+          <p>
+            You&apos;re signed in as a <strong className="text-gray-800">store owner</strong>.
+            Following a store (subscribe / <strong className="text-gray-800">My alerts</strong>)
+            needs a <strong className="text-gray-800">shopper</strong> login — owners can&apos;t
+            create shopper alerts from this dashboard account.
+          </p>
+          <div className="mt-3 flex flex-col sm:flex-row flex-wrap gap-2">
+            <Link
+              href={`/login?callbackUrl=${encodeURIComponent(`/stores/${store.id}`)}`}
+              className="inline-flex justify-center items-center px-4 py-2 rounded-lg text-[13px] font-semibold bg-green-600 text-white hover:bg-green-800 transition-colors text-center"
+            >
+              Subscribe as shopper — log in
+            </Link>
+            <Link
+              href={`/signup/shopper?callbackUrl=${encodeURIComponent(`/stores/${store.id}`)}`}
+              className="inline-flex justify-center items-center px-4 py-2 rounded-lg text-[13px] font-semibold border border-gray-200 bg-white text-gray-800 hover:bg-gray-50 transition-colors text-center"
+            >
+              Subscribe as shopper — sign up
+            </Link>
+          </div>
+          <p className="mt-2 text-[12px] text-gray-500">
+            Tip: use an incognito window if you want to stay logged in as an owner in
+            another tab.
+          </p>
+        </div>
+      ) : (
+        <section className="mb-4 space-y-3" aria-labelledby="store-follow-heading">
+          <h2
+            id="store-follow-heading"
+            className="text-[17px] font-semibold text-gray-800 flex items-center gap-2"
+          >
+            <span aria-hidden>🔔</span>
+            {viewerRole === "shopper" && initialStoreFollow
+              ? "You’re following this store"
+              : "Follow this store"}
+          </h2>
+          <StoreAlertSubscribe
+            key={store.id}
+            storeId={store.id}
+            storeName={store.name}
+            initialSubscribed={initialStoreFollow}
+            viewerRole={viewerRole}
+          />
+        </section>
+      )}
 
       <ItemAvailabilitySearch
         storeId={store.id}
         storeName={store.name}
         storeAddress={store.address}
+        viewerRole={viewerRole}
       />
 
       {/* Fresh Today — Story 1 */}

--- a/app/(public)/stores/[id]/page.tsx
+++ b/app/(public)/stores/[id]/page.tsx
@@ -1,7 +1,10 @@
 // Story 1: Fresh Today (Shopper view)
 // Story 2: Deals This Week (Shopper view)
 // Story 12: No auth required
+// Shopper alerts: store follow + item restock (session-backed)
 
+import { AlertType } from "@/app/generated/prisma/client";
+import { auth } from "@/auth";
 import DealCard from "@/components/DealCard";
 import {
   enrichFreshUpdatesWithStale,
@@ -12,6 +15,7 @@ import { prisma } from "@/lib/prisma";
 import { notFound } from "next/navigation";
 import Link from "next/link";
 import ItemAvailabilitySearch from "@/components/ItemAvailabilitySearch";
+import StoreAlertSubscribe from "@/components/StoreAlertSubscribe";
 import StoreFreshUpdatesFeed from "@/components/StoreFreshUpdatesFeed";
 
 export const dynamic = "force-dynamic";
@@ -49,6 +53,21 @@ export default async function StoreProfilePage({
   });
 
   if (!store || !store.isPublished) notFound();
+
+  const session = await auth();
+  let initialStoreFollow = false;
+  if (session?.role === "shopper") {
+    const follow = await prisma.alert.findFirst({
+      where: {
+        shopperId: session.user.id,
+        type: AlertType.store_follow,
+        storeId: id,
+        isActive: true,
+      },
+      select: { id: true },
+    });
+    initialStoreFollow = Boolean(follow);
+  }
 
   const freshUpdatesDisplay = enrichFreshUpdatesWithStale(
     store.freshUpdates,
@@ -108,6 +127,14 @@ export default async function StoreProfilePage({
             </div>
           )}
         </div>
+      </div>
+
+      <div className="mb-4">
+        <StoreAlertSubscribe
+          storeId={store.id}
+          storeName={store.name}
+          initialSubscribed={initialStoreFollow}
+        />
       </div>
 
       <ItemAvailabilitySearch

--- a/app/api/alerts/[id]/route.ts
+++ b/app/api/alerts/[id]/route.ts
@@ -1,35 +1,31 @@
 import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
+import { requireShopperSession } from "@/lib/require-shopper";
 
-// Story 5: DELETE /api/alerts/:id — Deactivate alert (shopper auth required)
+/** DELETE /api/alerts/:id — set isActive false for the logged-in shopper */
 export async function DELETE(
-  req: NextRequest,
-  { params }: { params: Promise<{ id: string }> }
+  _req: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
 ) {
-  try {
-    const shopperId =
-      req.headers.get("x-shopper-id") ?? req.nextUrl.searchParams.get("shopperId");
-    if (!shopperId) {
-      return NextResponse.json(
-        { error: "shopperId is required" },
-        { status: 400 }
-      );
-    }
+  const gate = await requireShopperSession();
+  if ("response" in gate) return gate.response;
 
-    const { id } = await params;
-    const existing = await prisma.alert.findUnique({ where: { id } });
-    if (!existing || existing.shopperId !== shopperId) {
-      return NextResponse.json({ error: "Alert not found" }, { status: 404 });
-    }
-
-    const alert = await prisma.alert.update({
-      where: { id },
-      data: { isActive: false },
-    });
-
-    return NextResponse.json(alert);
-  } catch (error) {
-    console.error("DELETE /api/alerts/:id error:", error);
-    return NextResponse.json({ error: "Failed to delete alert" }, { status: 500 });
+  const { id } = await params;
+  const existing = await prisma.alert.findUnique({ where: { id } });
+  if (!existing || existing.shopperId !== gate.shopperId) {
+    return NextResponse.json({ error: "Alert not found" }, { status: 404 });
   }
+
+  const alert = await prisma.alert.update({
+    where: { id },
+    data: { isActive: false },
+  });
+
+  return NextResponse.json({
+    id: alert.id,
+    isActive: alert.isActive,
+    type: alert.type,
+    storeId: alert.storeId,
+    itemId: alert.itemId,
+  });
 }

--- a/app/api/alerts/route.ts
+++ b/app/api/alerts/route.ts
@@ -1,83 +1,93 @@
 import { NextRequest, NextResponse } from "next/server";
-import { prisma } from "@/lib/prisma";
 import { AlertType } from "@/app/generated/prisma/client";
+import { prisma } from "@/lib/prisma";
+import { requireShopperSession } from "@/lib/require-shopper";
 
-function getShopperId(req: NextRequest): string | null {
-  return (
-    req.headers.get("x-shopper-id") ??
-    req.nextUrl.searchParams.get("shopperId") ??
-    null
-  );
+function serializeAlert(row: {
+  id: string;
+  shopperId: string;
+  itemId: string | null;
+  storeId: string | null;
+  type: AlertType;
+  isActive: boolean;
+  createdAt: Date;
+  store: { id: string; name: string } | null;
+  item: { id: string; name: string } | null;
+}) {
+  return {
+    id: row.id,
+    shopperId: row.shopperId,
+    itemId: row.itemId,
+    storeId: row.storeId,
+    type: row.type,
+    isActive: row.isActive,
+    createdAt: row.createdAt.toISOString(),
+    store: row.store,
+    item: row.item,
+  };
 }
 
-// Story 5: GET /api/alerts — List own active alerts (shopper auth required)
-export async function GET(req: NextRequest) {
-  try {
-    const shopperId = getShopperId(req);
-    if (!shopperId) {
-      return NextResponse.json(
-        { error: "shopperId is required" },
-        { status: 400 }
-      );
-    }
+/** GET /api/alerts — active alerts for the logged-in shopper */
+export async function GET() {
+  const gate = await requireShopperSession();
+  if ("response" in gate) return gate.response;
 
-    const alerts = await prisma.alert.findMany({
-      where: { shopperId, isActive: true },
-      orderBy: { createdAt: "desc" },
-    });
+  const alerts = await prisma.alert.findMany({
+    where: { shopperId: gate.shopperId, isActive: true },
+    orderBy: { createdAt: "desc" },
+    include: {
+      store: { select: { id: true, name: true } },
+      item: { select: { id: true, name: true } },
+    },
+  });
 
-    return NextResponse.json(alerts);
-  } catch (error) {
-    console.error("GET /api/alerts error:", error);
-    return NextResponse.json({ error: "Failed to list alerts" }, { status: 500 });
-  }
+  return NextResponse.json({
+    alerts: alerts.map(serializeAlert),
+  });
 }
 
-// Story 5: POST /api/alerts — Create alert (item_restock or store_follow)
+/** POST /api/alerts — create store_follow or item_restock (session shopper only) */
 export async function POST(req: NextRequest) {
-  try {
-    const body = (await req.json()) as {
-      shopperId?: string;
-      itemId?: string | null;
-      storeId?: string | null;
-      type?: string;
-    };
+  const gate = await requireShopperSession();
+  if ("response" in gate) return gate.response;
 
-    const shopperId = body.shopperId ?? getShopperId(req);
-    if (!shopperId) {
-      return NextResponse.json(
-        { error: "shopperId is required" },
-        { status: 400 }
-      );
-    }
+  const body = (await req.json().catch(() => null)) as Record<string, unknown> | null;
+  if (!body || typeof body !== "object") {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
 
-    if (body.type !== AlertType.item_restock && body.type !== AlertType.store_follow) {
-      return NextResponse.json(
-        { error: "type must be item_restock or store_follow" },
-        { status: 400 }
-      );
-    }
+  const typeRaw = body.type;
+  if (typeRaw !== AlertType.item_restock && typeRaw !== AlertType.store_follow) {
+    return NextResponse.json(
+      { error: "type must be item_restock or store_follow" },
+      { status: 400 },
+    );
+  }
+  const type = typeRaw as AlertType;
 
-    if (body.type === AlertType.item_restock && !body.itemId) {
-      return NextResponse.json(
-        { error: "itemId is required for item_restock alerts" },
-        { status: 400 }
-      );
-    }
-
-    if (body.type === AlertType.store_follow && !body.storeId) {
+  if (type === AlertType.store_follow) {
+    const storeId = typeof body.storeId === "string" ? body.storeId.trim() : "";
+    if (!storeId) {
       return NextResponse.json(
         { error: "storeId is required for store_follow alerts" },
-        { status: 400 }
+        { status: 400 },
       );
+    }
+
+    const store = await prisma.store.findFirst({
+      where: { id: storeId, isPublished: true },
+      select: { id: true },
+    });
+    if (!store) {
+      return NextResponse.json({ error: "Store not found or not published" }, { status: 400 });
     }
 
     const existing = await prisma.alert.findFirst({
       where: {
-        shopperId,
-        type: body.type,
-        itemId: body.itemId ?? null,
-        storeId: body.storeId ?? null,
+        shopperId: gate.shopperId,
+        type: AlertType.store_follow,
+        storeId,
+        itemId: null,
       },
     });
 
@@ -85,19 +95,77 @@ export async function POST(req: NextRequest) {
       ? await prisma.alert.update({
           where: { id: existing.id },
           data: { isActive: true },
+          include: {
+            store: { select: { id: true, name: true } },
+            item: { select: { id: true, name: true } },
+          },
         })
       : await prisma.alert.create({
           data: {
-            shopperId,
-            type: body.type,
-            itemId: body.itemId ?? null,
-            storeId: body.storeId ?? null,
+            shopperId: gate.shopperId,
+            type: AlertType.store_follow,
+            storeId,
+            itemId: null,
+          },
+          include: {
+            store: { select: { id: true, name: true } },
+            item: { select: { id: true, name: true } },
           },
         });
 
-    return NextResponse.json(alert, { status: 201 });
-  } catch (error) {
-    console.error("POST /api/alerts error:", error);
-    return NextResponse.json({ error: "Failed to create alert" }, { status: 500 });
+    return NextResponse.json(serializeAlert(alert), { status: 201 });
   }
+
+  const storeId = typeof body.storeId === "string" ? body.storeId.trim() : "";
+  const itemId = typeof body.itemId === "string" ? body.itemId.trim() : "";
+  if (!storeId || !itemId) {
+    return NextResponse.json(
+      { error: "storeId and itemId are required for item_restock alerts" },
+      { status: 400 },
+    );
+  }
+
+  const item = await prisma.item.findFirst({
+    where: { id: itemId, storeId },
+    include: { store: { select: { isPublished: true } } },
+  });
+  if (!item || !item.store.isPublished) {
+    return NextResponse.json(
+      { error: "Item not found or store is not published" },
+      { status: 400 },
+    );
+  }
+
+  const existing = await prisma.alert.findFirst({
+    where: {
+      shopperId: gate.shopperId,
+      type: AlertType.item_restock,
+      storeId,
+      itemId,
+    },
+  });
+
+  const alert = existing
+    ? await prisma.alert.update({
+        where: { id: existing.id },
+        data: { isActive: true },
+        include: {
+          store: { select: { id: true, name: true } },
+          item: { select: { id: true, name: true } },
+        },
+      })
+    : await prisma.alert.create({
+        data: {
+          shopperId: gate.shopperId,
+          type: AlertType.item_restock,
+          storeId,
+          itemId,
+        },
+        include: {
+          store: { select: { id: true, name: true } },
+          item: { select: { id: true, name: true } },
+        },
+      });
+
+  return NextResponse.json(serializeAlert(alert), { status: 201 });
 }

--- a/app/api/shopper/notifications/[id]/route.ts
+++ b/app/api/shopper/notifications/[id]/route.ts
@@ -1,0 +1,36 @@
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { requireShopperSession } from "@/lib/require-shopper";
+
+/** PATCH /api/shopper/notifications/:id — mark read ({ "read": true }) or unread ({ "read": false }). */
+export async function PATCH(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const gate = await requireShopperSession();
+  if ("response" in gate) return gate.response;
+
+  const { id } = await params;
+  const row = await prisma.shopperNotification.findUnique({ where: { id } });
+  if (!row || row.shopperId !== gate.shopperId) {
+    return NextResponse.json({ error: "Not found" }, { status: 404 });
+  }
+
+  let read = true;
+  try {
+    const body = (await req.json().catch(() => null)) as { read?: unknown } | null;
+    if (body && typeof body.read === "boolean") read = body.read;
+  } catch {
+    /* default read true */
+  }
+
+  const updated = await prisma.shopperNotification.update({
+    where: { id },
+    data: { readAt: read ? new Date() : null },
+  });
+
+  return NextResponse.json({
+    id: updated.id,
+    readAt: updated.readAt?.toISOString() ?? null,
+  });
+}

--- a/app/api/shopper/notifications/[id]/route.ts
+++ b/app/api/shopper/notifications/[id]/route.ts
@@ -17,12 +17,8 @@ export async function PATCH(
   }
 
   let read = true;
-  try {
-    const body = (await req.json().catch(() => null)) as { read?: unknown } | null;
-    if (body && typeof body.read === "boolean") read = body.read;
-  } catch {
-    /* default read true */
-  }
+  const body = (await req.json().catch(() => null)) as { read?: unknown } | null;
+  if (body && typeof body.read === "boolean") read = body.read;
 
   const updated = await prisma.shopperNotification.update({
     where: { id },

--- a/app/api/shopper/notifications/route.ts
+++ b/app/api/shopper/notifications/route.ts
@@ -1,18 +1,34 @@
-import { NextResponse } from "next/server";
+import { type NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { requireShopperSession } from "@/lib/require-shopper";
 
-const TAKE = 50;
+const DEFAULT_TAKE = 50;
+const MAX_TAKE = 100;
+const MAX_SKIP = 5_000;
 
-/** GET /api/shopper/notifications — inbox items for the logged-in shopper (newest first). */
-export async function GET() {
+function clampInt(raw: string | null, fallback: number, max: number): number {
+  const n = Number.parseInt(raw ?? "", 10);
+  if (!Number.isFinite(n) || n < 0) return fallback;
+  return Math.min(n, max);
+}
+
+/** GET /api/shopper/notifications — inbox (newest first). Query: ?take=&skip= for pagination. */
+export async function GET(req: NextRequest) {
   const gate = await requireShopperSession();
   if ("response" in gate) return gate.response;
+
+  const take = clampInt(
+    req.nextUrl.searchParams.get("take"),
+    DEFAULT_TAKE,
+    MAX_TAKE,
+  );
+  const skip = clampInt(req.nextUrl.searchParams.get("skip"), 0, MAX_SKIP);
 
   const rows = await prisma.shopperNotification.findMany({
     where: { shopperId: gate.shopperId },
     orderBy: { createdAt: "desc" },
-    take: TAKE,
+    skip,
+    take,
     select: {
       id: true,
       kind: true,
@@ -34,5 +50,8 @@ export async function GET() {
       createdAt: n.createdAt.toISOString(),
       store: n.store,
     })),
+    hasMore: rows.length === take,
+    skip,
+    take,
   });
 }

--- a/app/api/shopper/notifications/route.ts
+++ b/app/api/shopper/notifications/route.ts
@@ -1,0 +1,38 @@
+import { NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { requireShopperSession } from "@/lib/require-shopper";
+
+const TAKE = 50;
+
+/** GET /api/shopper/notifications — inbox items for the logged-in shopper (newest first). */
+export async function GET() {
+  const gate = await requireShopperSession();
+  if ("response" in gate) return gate.response;
+
+  const rows = await prisma.shopperNotification.findMany({
+    where: { shopperId: gate.shopperId },
+    orderBy: { createdAt: "desc" },
+    take: TAKE,
+    select: {
+      id: true,
+      kind: true,
+      title: true,
+      body: true,
+      readAt: true,
+      createdAt: true,
+      store: { select: { id: true, name: true } },
+    },
+  });
+
+  return NextResponse.json({
+    notifications: rows.map((n) => ({
+      id: n.id,
+      kind: n.kind,
+      title: n.title,
+      body: n.body,
+      readAt: n.readAt?.toISOString() ?? null,
+      createdAt: n.createdAt.toISOString(),
+      store: n.store,
+    })),
+  });
+}

--- a/app/api/stores/[id]/deals/route.ts
+++ b/app/api/stores/[id]/deals/route.ts
@@ -27,6 +27,21 @@ function dealJson(deal: {
   };
 }
 
+function jsonCreatedDeal(
+  deal: Parameters<typeof dealJson>[0],
+  storeId: string,
+  store: { name: string },
+) {
+  void notifyStoreFollowersOfNewDeal({
+    storeId,
+    storeName: store.name,
+    dealId: deal.id,
+    dealTitle: deal.title,
+    price: deal.price,
+  });
+  return NextResponse.json({ deal: dealJson(deal) }, { status: 201 });
+}
+
 function parsePrice(raw: unknown): { ok: true; value: Prisma.Decimal } | { ok: false; error: string } {
   if (raw === undefined || raw === null || raw === "") {
     return { ok: false, error: "price is required" };
@@ -168,15 +183,7 @@ export async function POST(request: NextRequest, context: RouteContext) {
       },
     });
 
-    void notifyStoreFollowersOfNewDeal({
-      storeId,
-      storeName: store.name,
-      dealId: deal.id,
-      dealTitle: deal.title,
-      price: deal.price,
-    });
-
-    return NextResponse.json({ deal: dealJson(deal) }, { status: 201 });
+    return jsonCreatedDeal(deal, storeId, store);
   }
 
   const priceResult = parsePrice(body.price);
@@ -221,13 +228,5 @@ export async function POST(request: NextRequest, context: RouteContext) {
     },
   });
 
-  void notifyStoreFollowersOfNewDeal({
-    storeId,
-    storeName: store.name,
-    dealId: deal.id,
-    dealTitle: deal.title,
-    price: deal.price,
-  });
-
-  return NextResponse.json({ deal: dealJson(deal) }, { status: 201 });
+  return jsonCreatedDeal(deal, storeId, store);
 }

--- a/app/api/stores/[id]/deals/route.ts
+++ b/app/api/stores/[id]/deals/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { Prisma } from "@/app/generated/prisma/client";
+import { notifyStoreFollowersOfNewDeal } from "@/lib/notify-store-followers";
 import { prisma } from "@/lib/prisma";
 import { requireStoreOwnerForStore } from "@/lib/require-store-owner";
 
@@ -99,6 +100,7 @@ export async function POST(request: NextRequest, context: RouteContext) {
   const { id: storeId } = await context.params;
   const gate = await requireStoreOwnerForStore(storeId);
   if ("response" in gate) return gate.response;
+  const { store } = gate;
 
   const now = new Date();
   const body = await request.json().catch(() => null);
@@ -166,6 +168,14 @@ export async function POST(request: NextRequest, context: RouteContext) {
       },
     });
 
+    void notifyStoreFollowersOfNewDeal({
+      storeId,
+      storeName: store.name,
+      dealId: deal.id,
+      dealTitle: deal.title,
+      price: deal.price,
+    });
+
     return NextResponse.json({ deal: dealJson(deal) }, { status: 201 });
   }
 
@@ -209,6 +219,14 @@ export async function POST(request: NextRequest, context: RouteContext) {
       isExpired: false,
       expiryNotifiedAt: null,
     },
+  });
+
+  void notifyStoreFollowersOfNewDeal({
+    storeId,
+    storeName: store.name,
+    dealId: deal.id,
+    dealTitle: deal.title,
+    price: deal.price,
   });
 
   return NextResponse.json({ deal: dealJson(deal) }, { status: 201 });

--- a/app/api/stores/[id]/updates/route.ts
+++ b/app/api/stores/[id]/updates/route.ts
@@ -6,6 +6,7 @@ import {
   parseFreshUpdatePostBody,
 } from "@/lib/fresh-updates";
 import { broadcastPostEvent } from "@/lib/post-events";
+import { notifyStoreFollowersOfFreshUpdate } from "@/lib/notify-store-followers";
 import { prisma } from "@/lib/prisma";
 import { requireStoreOwnerForStore } from "@/lib/require-store-owner";
 
@@ -59,6 +60,7 @@ export async function POST(
 
   const gate = await requireStoreOwnerForStore(storeId);
   if ("response" in gate) return gate.response;
+  const { store } = gate;
 
   const body = await request.json().catch(() => null);
   const parsed = parseFreshUpdatePostBody(body);
@@ -78,6 +80,14 @@ export async function POST(
     storeId,
     postId: update.id,
     type: "POST_CREATE",
+  });
+
+  void notifyStoreFollowersOfFreshUpdate({
+    storeId,
+    storeName: store.name,
+    freshUpdateId: update.id,
+    itemName: update.itemName,
+    note: update.note,
   });
 
   return NextResponse.json({ update }, { status: 201 });

--- a/app/auth/signup-shopper/route.ts
+++ b/app/auth/signup-shopper/route.ts
@@ -3,7 +3,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { Prisma } from "@/app/generated/prisma/client";
 import { prisma } from "@/lib/prisma";
 import { runCredentialsSignIn } from "@/lib/credentials-sign-in-response";
-import { validateOwnerSignup } from "@/lib/validate-owner-signup";
+import { validateShopperSignup } from "@/lib/validate-shopper-signup";
 
 const BCRYPT_ROUNDS = 12;
 
@@ -15,43 +15,43 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
   }
 
-  const validated = validateOwnerSignup(body);
+  const validated = validateShopperSignup(body);
   if (!validated.ok) {
     return NextResponse.json(
       { error: "Validation failed", fieldErrors: validated.errors },
-      { status: 400 }
+      { status: 400 },
     );
   }
 
   const { email, password, name, callbackUrl } = validated.data;
 
-  const existing = await prisma.storeOwner.findUnique({
+  const existingOwner = await prisma.storeOwner.findUnique({
     where: { email },
     select: { id: true },
   });
-  if (existing) {
+  if (existingOwner) {
     return NextResponse.json(
-      { error: "An account with this email already exists." },
-      { status: 409 }
+      { error: "This email is already registered as a store owner." },
+      { status: 409 },
     );
   }
 
-  const shopperDup = await prisma.shopper.findUnique({
+  const existingShopper = await prisma.shopper.findUnique({
     where: { email },
     select: { id: true },
   });
-  if (shopperDup) {
+  if (existingShopper) {
     return NextResponse.json(
-      { error: "This email is already registered as a shopper." },
-      { status: 409 }
+      { error: "An account with this email already exists." },
+      { status: 409 },
     );
   }
 
   const passwordHash = await bcrypt.hash(password, BCRYPT_ROUNDS);
 
-  let owner;
+  let shopper;
   try {
-    owner = await prisma.storeOwner.create({
+    shopper = await prisma.shopper.create({
       data: {
         email,
         name,
@@ -69,19 +69,14 @@ export async function POST(req: NextRequest) {
         { status: 409 },
       );
     }
-    console.error("POST /auth/signup create error:", e);
+    console.error("POST /auth/signup-shopper create error:", e);
     return NextResponse.json(
       { error: "Could not create account. Try again." },
       { status: 500 },
     );
   }
 
-  const signInRes = await runCredentialsSignIn(
-    req,
-    email,
-    password,
-    callbackUrl,
-  );
+  const signInRes = await runCredentialsSignIn(req, email, password, callbackUrl);
   const setCookies = signInRes.headers.getSetCookie?.() ?? [];
   const signInJson = (await signInRes.json().catch(() => null)) as {
     ok?: boolean;
@@ -93,9 +88,9 @@ export async function POST(req: NextRequest) {
       {
         error:
           "Account was created but automatic sign-in failed. Please log in manually.",
-        user: owner,
+        user: shopper,
       },
-      { status: 201 }
+      { status: 201 },
     );
   }
 
@@ -103,9 +98,9 @@ export async function POST(req: NextRequest) {
     {
       ok: true,
       redirectUrl: signInJson.redirectUrl,
-      user: owner,
+      user: shopper,
     },
-    { status: 201 }
+    { status: 201 },
   );
 
   for (const cookie of setCookies) {

--- a/auth.config.ts
+++ b/auth.config.ts
@@ -15,6 +15,8 @@ export const authConfig = {
         const email = credentials?.email as string | undefined;
         const password = credentials?.password as string | undefined;
 
+        // Owner session is tried first, then shopper. Same /login form for both; wrong-type
+        // credentials simply fail with a generic error (no role hint) — see README for QA emails.
         const owner = await authenticateStoreOwner(email, password);
         if (owner) {
           return {

--- a/auth.config.ts
+++ b/auth.config.ts
@@ -1,5 +1,6 @@
 import type { NextAuthConfig } from "next-auth";
 import Credentials from "next-auth/providers/credentials";
+import { authenticateShopper } from "@/lib/authenticate-shopper";
 import { authenticateStoreOwner } from "@/lib/authenticate-store-owner";
 
 export const authConfig = {
@@ -11,17 +12,32 @@ export const authConfig = {
         password: { label: "Password", type: "password" },
       },
       async authorize(credentials) {
-        const user = await authenticateStoreOwner(
-          credentials?.email as string | undefined,
-          credentials?.password as string | undefined
-        );
-        if (!user) return null;
-        return {
-          id: user.id,
-          email: user.email,
-          name: user.name,
-          storeId: user.storeId,
-        };
+        const email = credentials?.email as string | undefined;
+        const password = credentials?.password as string | undefined;
+
+        const owner = await authenticateStoreOwner(email, password);
+        if (owner) {
+          return {
+            id: owner.id,
+            email: owner.email,
+            name: owner.name,
+            storeId: owner.storeId,
+            role: "owner" as const,
+          };
+        }
+
+        const shopper = await authenticateShopper(email, password);
+        if (shopper) {
+          return {
+            id: shopper.id,
+            email: shopper.email,
+            name: shopper.name,
+            storeId: null,
+            role: "shopper" as const,
+          };
+        }
+
+        return null;
       },
     }),
   ],
@@ -33,15 +49,17 @@ export const authConfig = {
   callbacks: {
     async jwt({ token, user }) {
       if (user) {
-        token.ownerId = user.id!;
-        token.storeId = (user as { storeId?: string | null }).storeId ?? null;
+        token.role = user.role ?? "owner";
+        token.storeId = user.storeId ?? null;
       }
       return token;
     },
     async session({ session, token }) {
-      session.user.id = token.ownerId as string;
-      (session as { storeId?: string | null }).storeId =
-        token.storeId as string | null;
+      if (token.sub) {
+        session.user.id = token.sub;
+      }
+      session.role = (token.role as "owner" | "shopper" | undefined) ?? "owner";
+      session.storeId = (token.storeId as string | null) ?? null;
       return session;
     },
   },

--- a/components/ItemAvailabilitySearch.tsx
+++ b/components/ItemAvailabilitySearch.tsx
@@ -1,6 +1,9 @@
 "use client";
 
-import { useMemo, useState } from "react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { useSession } from "next-auth/react";
+import { useMemo, useState, useEffect } from "react";
 
 type SearchResult = {
   id: string;
@@ -18,8 +21,6 @@ type Props = {
   storeName: string;
   storeAddress: string;
 };
-
-const DEMO_SHOPPER_ID = "55555555-5555-5555-5555-555555555555";
 
 function toRelativeTime(isoDate: string): string {
   const timestamp = new Date(isoDate).getTime();
@@ -50,14 +51,51 @@ export default function ItemAvailabilitySearch({
   storeName,
   storeAddress,
 }: Props) {
+  const router = useRouter();
+  const { data: session, status } = useSession();
   const [query, setQuery] = useState("");
   const [results, setResults] = useState<SearchResult[]>([]);
   const [loading, setLoading] = useState(false);
   const [searched, setSearched] = useState(false);
-  const [notifyByItemId, setNotifyByItemId] = useState<Record<string, boolean>>({});
+  const [notifyByItemId, setNotifyByItemId] = useState<Record<string, boolean>>(
+    {},
+  );
+
+  const callbackPath = `/stores/${storeId}`;
+  const loginHref = `/login?callbackUrl=${encodeURIComponent(callbackPath)}`;
 
   const hasQuery = query.trim().length > 0;
   const queryHint = useMemo(() => (hasQuery ? query.trim() : ""), [hasQuery, query]);
+
+  useEffect(() => {
+    if (status !== "authenticated" || session?.role !== "shopper") {
+      setNotifyByItemId({});
+      return;
+    }
+
+    let cancelled = false;
+    (async () => {
+      const res = await fetch("/api/alerts", { credentials: "include" });
+      if (!res.ok || cancelled) return;
+      const data = (await res.json()) as {
+        alerts?: Array<{ type: string; itemId: string | null; storeId: string | null }>;
+      };
+      const next: Record<string, boolean> = {};
+      for (const a of data.alerts ?? []) {
+        if (
+          a.type === "item_restock" &&
+          a.itemId &&
+          a.storeId === storeId
+        ) {
+          next[a.itemId] = true;
+        }
+      }
+      setNotifyByItemId(next);
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [status, session?.role, storeId]);
 
   async function runSearch(e: React.FormEvent<HTMLFormElement>) {
     e.preventDefault();
@@ -83,47 +121,67 @@ export default function ItemAvailabilitySearch({
   }
 
   async function toggleNotify(item: SearchResult) {
+    if (status !== "authenticated" || session?.role !== "shopper") {
+      router.push(loginHref);
+      return;
+    }
+
     const currentlyOn = Boolean(notifyByItemId[item.id]);
     if (!currentlyOn) {
+      setNotifyByItemId((prev) => ({ ...prev, [item.id]: true }));
       const res = await fetch("/api/alerts", {
         method: "POST",
+        credentials: "include",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
-          shopperId: DEMO_SHOPPER_ID,
           type: "item_restock",
           itemId: item.id,
           storeId: item.store_id,
         }),
       });
-      if (res.ok) {
-        setNotifyByItemId((prev) => ({ ...prev, [item.id]: true }));
+      if (!res.ok) {
+        setNotifyByItemId((prev) => {
+          const n = { ...prev };
+          delete n[item.id];
+          return n;
+        });
       }
+      router.refresh();
       return;
     }
 
-    const listRes = await fetch(`/api/alerts?shopperId=${DEMO_SHOPPER_ID}`);
-    if (!listRes.ok) return;
-    const alerts = (await listRes.json()) as Array<{
-      id: string;
-      itemId: string | null;
-      type: string;
-    }>;
-    const existing = alerts.find(
-      (alert) => alert.type === "item_restock" && alert.itemId === item.id
-    );
-    if (!existing) {
-      setNotifyByItemId((prev) => ({ ...prev, [item.id]: false }));
+    setNotifyByItemId((prev) => {
+      const n = { ...prev };
+      delete n[item.id];
+      return n;
+    });
+
+    const listRes = await fetch("/api/alerts", { credentials: "include" });
+    if (!listRes.ok) {
+      setNotifyByItemId((prev) => ({ ...prev, [item.id]: true }));
       return;
     }
-
-    const deleteRes = await fetch(
-      `/api/alerts/${existing.id}?shopperId=${DEMO_SHOPPER_ID}`,
-      { method: "DELETE" }
+    const data = (await listRes.json()) as {
+      alerts?: Array<{ id: string; itemId: string | null; type: string }>;
+    };
+    const existing = (data.alerts ?? []).find(
+      (alert) =>
+        alert.type === "item_restock" && alert.itemId === item.id,
     );
-    if (deleteRes.ok) {
-      setNotifyByItemId((prev) => ({ ...prev, [item.id]: false }));
+    if (!existing) return;
+
+    const deleteRes = await fetch(`/api/alerts/${existing.id}`, {
+      method: "DELETE",
+      credentials: "include",
+    });
+    if (!deleteRes.ok) {
+      setNotifyByItemId((prev) => ({ ...prev, [item.id]: true }));
+      return;
     }
+    router.refresh();
   }
+
+  const hideNotifyForOwner = session?.role === "owner";
 
   return (
     <div className="bg-white rounded-2xl border border-gray-200 p-6 mb-4">
@@ -180,17 +238,27 @@ export default function ItemAvailabilitySearch({
               >
                 {item.stock_count === 0 ? "Out of Stock" : "In-Stock"}
               </span>
-              <button
-                type="button"
-                onClick={() => toggleNotify(item)}
-                className={`text-[12px] px-2.5 py-1 rounded-full border transition-colors ${
-                  notifyByItemId[item.id]
-                    ? "border-green-300 bg-green-50 text-green-700"
-                    : "border-gray-200 bg-white text-gray-600 hover:border-green-300 hover:text-green-700"
-                }`}
-              >
-                {notifyByItemId[item.id] ? "Notify me: On" : "Notify me"}
-              </button>
+              {!hideNotifyForOwner &&
+                (status === "unauthenticated" ? (
+                  <Link
+                    href={loginHref}
+                    className="text-[12px] px-2.5 py-1 rounded-full border border-gray-200 bg-white text-gray-600 hover:border-green-300 hover:text-green-700 transition-colors"
+                  >
+                    Notify me
+                  </Link>
+                ) : session?.role === "shopper" ? (
+                  <button
+                    type="button"
+                    onClick={() => toggleNotify(item)}
+                    className={`text-[12px] px-2.5 py-1 rounded-full border transition-colors ${
+                      notifyByItemId[item.id]
+                        ? "border-green-300 bg-green-50 text-green-700"
+                        : "border-gray-200 bg-white text-gray-600 hover:border-green-300 hover:text-green-700"
+                    }`}
+                  >
+                    {notifyByItemId[item.id] ? "Notify me: On" : "Notify me"}
+                  </button>
+                ) : null)}
             </div>
           </div>
         ))}

--- a/components/ItemAvailabilitySearch.tsx
+++ b/components/ItemAvailabilitySearch.tsx
@@ -1,8 +1,8 @@
 "use client";
 
+import type { ViewerRole } from "@/lib/viewer-role";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
-import { useSession } from "next-auth/react";
 import { useMemo, useState, useEffect } from "react";
 
 type SearchResult = {
@@ -20,6 +20,7 @@ type Props = {
   storeId: string;
   storeName: string;
   storeAddress: string;
+  viewerRole: ViewerRole;
 };
 
 function toRelativeTime(isoDate: string): string {
@@ -50,9 +51,9 @@ export default function ItemAvailabilitySearch({
   storeId,
   storeName,
   storeAddress,
+  viewerRole,
 }: Props) {
   const router = useRouter();
-  const { data: session, status } = useSession();
   const [query, setQuery] = useState("");
   const [results, setResults] = useState<SearchResult[]>([]);
   const [loading, setLoading] = useState(false);
@@ -68,7 +69,7 @@ export default function ItemAvailabilitySearch({
   const queryHint = useMemo(() => (hasQuery ? query.trim() : ""), [hasQuery, query]);
 
   useEffect(() => {
-    if (status !== "authenticated" || session?.role !== "shopper") {
+    if (viewerRole !== "shopper") {
       setNotifyByItemId({});
       return;
     }
@@ -95,7 +96,7 @@ export default function ItemAvailabilitySearch({
     return () => {
       cancelled = true;
     };
-  }, [status, session?.role, storeId]);
+  }, [viewerRole, storeId]);
 
   async function runSearch(e: React.FormEvent<HTMLFormElement>) {
     e.preventDefault();
@@ -121,7 +122,7 @@ export default function ItemAvailabilitySearch({
   }
 
   async function toggleNotify(item: SearchResult) {
-    if (status !== "authenticated" || session?.role !== "shopper") {
+    if (viewerRole !== "shopper") {
       router.push(loginHref);
       return;
     }
@@ -181,7 +182,7 @@ export default function ItemAvailabilitySearch({
     router.refresh();
   }
 
-  const hideNotifyForOwner = session?.role === "owner";
+  const hideNotifyForOwner = viewerRole === "owner";
 
   return (
     <div className="bg-white rounded-2xl border border-gray-200 p-6 mb-4">
@@ -239,14 +240,14 @@ export default function ItemAvailabilitySearch({
                 {item.stock_count === 0 ? "Out of Stock" : "In-Stock"}
               </span>
               {!hideNotifyForOwner &&
-                (status === "unauthenticated" ? (
+                (viewerRole === null ? (
                   <Link
                     href={loginHref}
                     className="text-[12px] px-2.5 py-1 rounded-full border border-gray-200 bg-white text-gray-600 hover:border-green-300 hover:text-green-700 transition-colors"
                   >
                     Notify me
                   </Link>
-                ) : session?.role === "shopper" ? (
+                ) : viewerRole === "shopper" ? (
                   <button
                     type="button"
                     onClick={() => toggleNotify(item)}

--- a/components/MobileNav.tsx
+++ b/components/MobileNav.tsx
@@ -3,5 +3,10 @@ import MobileNavClient from "@/components/MobileNavClient";
 
 export default async function MobileNav() {
   const session = await auth();
-  return <MobileNavClient authed={!!session?.user} />;
+  return (
+    <MobileNavClient
+      authed={!!session?.user}
+      isShopper={session?.role === "shopper"}
+    />
+  );
 }

--- a/components/MobileNavClient.tsx
+++ b/components/MobileNavClient.tsx
@@ -9,14 +9,22 @@ const baseItems = [
   { href: "/deals", label: "Deals", icon: "🏷" },
 ] as const;
 
-export default function MobileNavClient({ authed }: { authed: boolean }) {
+export default function MobileNavClient({
+  authed,
+  isShopper,
+}: {
+  authed: boolean;
+  isShopper: boolean;
+}) {
   const pathname = usePathname();
 
-  const accountHref = authed ? "/dashboard" : "/login";
-  const accountLabel = authed ? "Owner" : "Account";
+  const accountHref = authed ? (isShopper ? "/my-alerts" : "/dashboard") : "/login";
+  const accountLabel = authed ? (isShopper ? "Alerts" : "Owner") : "Account";
   const accountActive =
     authed &&
-    (pathname === "/dashboard" || pathname.startsWith("/dashboard/"));
+    (isShopper
+      ? pathname === "/my-alerts"
+      : pathname === "/dashboard" || pathname.startsWith("/dashboard/"));
 
   const items = [
     ...baseItems.map((item) => ({
@@ -32,7 +40,8 @@ export default function MobileNavClient({ authed }: { authed: boolean }) {
         (!authed &&
           (pathname === "/login" ||
             pathname.startsWith("/login/") ||
-            pathname === "/signup")),
+            pathname === "/signup" ||
+            pathname.startsWith("/signup/"))),
     },
   ];
 

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -5,6 +5,7 @@ import SignOutButton from "@/components/SignOutButton";
 export default async function Navbar() {
   const session = await auth();
   const authed = !!session?.user;
+  const isShopper = session?.role === "shopper";
 
   return (
     <header className="sticky top-0 z-50 border-b border-gray-200 bg-white">
@@ -43,12 +44,21 @@ export default async function Navbar() {
 
         {authed ? (
           <div className="flex flex-wrap gap-2 items-center justify-end ml-auto">
-            <Link
-              href="/dashboard"
-              className="px-4 py-1.5 rounded-md text-sm font-medium text-white bg-green-600 hover:bg-green-800 transition-colors"
-            >
-              Owner portal
-            </Link>
+            {isShopper ? (
+              <Link
+                href="/my-alerts"
+                className="px-4 py-1.5 rounded-md text-sm font-medium text-white bg-green-600 hover:bg-green-800 transition-colors"
+              >
+                My alerts
+              </Link>
+            ) : (
+              <Link
+                href="/dashboard"
+                className="px-4 py-1.5 rounded-md text-sm font-medium text-white bg-green-600 hover:bg-green-800 transition-colors"
+              >
+                Owner portal
+              </Link>
+            )}
             <SignOutButton className="px-4 py-1.5 rounded-md text-sm font-medium text-gray-600 border border-gray-200 hover:bg-gray-100 transition-colors" />
           </div>
         ) : (

--- a/components/StoreAlertSubscribe.tsx
+++ b/components/StoreAlertSubscribe.tsx
@@ -1,27 +1,35 @@
 "use client";
 
 import Link from "next/link";
+import type { ViewerRole } from "@/lib/viewer-role";
 import { useRouter } from "next/navigation";
-import { useSession } from "next-auth/react";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 
 type Props = {
   storeId: string;
   storeName: string;
   /** Server-known active store_follow subscription */
   initialSubscribed: boolean;
+  /** From server auth() — client useSession can lag behind this */
+  viewerRole: ViewerRole;
 };
 
 export default function StoreAlertSubscribe({
   storeId,
   storeName,
   initialSubscribed,
+  viewerRole,
 }: Props) {
   const router = useRouter();
-  const { data: session, status } = useSession();
+  // Must match server on first paint — do not read sessionStorage here (hydration error).
   const [subscribed, setSubscribed] = useState(initialSubscribed);
   const [pending, setPending] = useState(false);
   const [error, setError] = useState<string | null>(null);
+
+  // When user unsubscribes elsewhere (e.g. My alerts) or server data updates, follow the server.
+  useEffect(() => {
+    setSubscribed(initialSubscribed);
+  }, [initialSubscribed, storeId]);
 
   const callbackPath = `/stores/${storeId}`;
   const loginHref = `/login?callbackUrl=${encodeURIComponent(callbackPath)}`;
@@ -29,7 +37,7 @@ export default function StoreAlertSubscribe({
 
   async function toggle() {
     setError(null);
-    if (status !== "authenticated" || session?.role !== "shopper") {
+    if (viewerRole !== "shopper") {
       router.push(loginHref);
       return;
     }
@@ -37,99 +45,111 @@ export default function StoreAlertSubscribe({
     if (!subscribed) {
       setSubscribed(true);
       setPending(true);
-      const res = await fetch("/api/alerts", {
-        method: "POST",
-        credentials: "include",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ type: "store_follow", storeId }),
-      });
-      setPending(false);
-      if (!res.ok) {
+      try {
+        const res = await fetch("/api/alerts", {
+          method: "POST",
+          credentials: "include",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ type: "store_follow", storeId }),
+        });
+        const payload = (await res.json().catch(() => ({}))) as {
+          error?: string;
+          isActive?: boolean;
+        };
+
+        if (!res.ok) {
+          setSubscribed(false);
+          setError(
+            typeof payload.error === "string"
+              ? payload.error
+              : res.status === 403
+                ? "This account can’t subscribe (try a shopper login)."
+                : res.status === 401
+                  ? "Sign in again, then retry."
+                  : "Could not subscribe.",
+          );
+          return;
+        }
+
+        setSubscribed(true);
+      } catch {
         setSubscribed(false);
-        const d = (await res.json().catch(() => ({}))) as { error?: string };
-        setError(d.error ?? "Could not subscribe.");
+        setError("Network error — check your connection and try again.");
+      } finally {
+        setPending(false);
       }
-      router.refresh();
       return;
     }
 
     setSubscribed(false);
     setPending(true);
-    const listRes = await fetch("/api/alerts", { credentials: "include" });
-    if (!listRes.ok) {
-      setSubscribed(true);
-      setPending(false);
-      setError("Could not update subscription.");
-      return;
-    }
-    const data = (await listRes.json()) as {
-      alerts?: Array<{ id: string; type: string; storeId: string | null }>;
-    };
-    const row = (data.alerts ?? []).find(
-      (a) => a.type === "store_follow" && a.storeId === storeId,
-    );
-    if (!row) {
-      setPending(false);
+    try {
+      const listRes = await fetch("/api/alerts", { credentials: "include" });
+      if (!listRes.ok) {
+        setSubscribed(true);
+        setError("Could not update subscription.");
+        return;
+      }
+      const data = (await listRes.json()) as {
+        alerts?: Array<{ id: string; type: string; storeId: string | null }>;
+      };
+      const row = (data.alerts ?? []).find(
+        (a) => a.type === "store_follow" && a.storeId === storeId,
+      );
+      if (!row) {
+        setSubscribed(false);
+        router.refresh();
+        return;
+      }
+      const del = await fetch(`/api/alerts/${row.id}`, {
+        method: "DELETE",
+        credentials: "include",
+      });
+      if (!del.ok) {
+        setSubscribed(true);
+        setError("Could not unsubscribe.");
+        return;
+      }
+      setSubscribed(false);
       router.refresh();
-      return;
+    } finally {
+      setPending(false);
     }
-    const del = await fetch(`/api/alerts/${row.id}`, {
-      method: "DELETE",
-      credentials: "include",
-    });
-    setPending(false);
-    if (!del.ok) {
-      setSubscribed(true);
-      setError("Could not unsubscribe.");
-      return;
-    }
-    router.refresh();
   }
 
-  if (status === "loading") {
-    return (
-      <div className="rounded-xl border border-gray-100 bg-gray-50 px-4 py-3 text-[13px] text-gray-400">
-        Checking alerts…
-      </div>
-    );
-  }
-
-  if (session?.role === "owner") {
-    return null;
-  }
-
-  if (status !== "authenticated") {
+  if (viewerRole === null) {
     return (
       <div className="rounded-xl border border-amber-100 bg-amber-50/80 px-4 py-3">
         <p className="text-[14px] text-amber-950 font-medium">
           Get deals &amp; restocks from {storeName}
         </p>
         <p className="text-[13px] text-amber-900/80 mt-1">
-          <Link href={loginHref} className="font-semibold text-green-700 hover:underline">
-            Sign in
-          </Link>{" "}
-          or{" "}
-          <Link href={signupHref} className="font-semibold text-green-700 hover:underline">
-            create a free shopper account
-          </Link>{" "}
-          to subscribe — you&apos;ll return here after.
+          Use a free shopper account so this store can land in{" "}
+          <strong className="text-amber-950">My alerts</strong>.
         </p>
+        <div className="mt-3 flex flex-col sm:flex-row flex-wrap gap-2">
+          <Link
+            href={loginHref}
+            className="inline-flex justify-center items-center px-4 py-2 rounded-lg text-[13px] font-semibold bg-green-600 text-white hover:bg-green-800 transition-colors text-center"
+          >
+            Subscribe — log in
+          </Link>
+          <Link
+            href={signupHref}
+            className="inline-flex justify-center items-center px-4 py-2 rounded-lg text-[13px] font-semibold border border-amber-200/80 text-amber-950 bg-white/70 hover:bg-white transition-colors text-center"
+          >
+            Subscribe — sign up free
+          </Link>
+        </div>
       </div>
     );
-  }
-
-  if (session.role !== "shopper") {
-    return null;
   }
 
   return (
     <div className="rounded-xl border border-gray-200 bg-white px-4 py-3">
       <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
         <div>
-          <p className="text-[14px] font-semibold text-gray-800">
-            {subscribed ? "You’re subscribed" : "Follow this store"}
-          </p>
-          <p className="text-[13px] text-gray-500 mt-0.5">
+          <p className="text-[13px] text-gray-600 leading-snug">
             {subscribed
               ? `We’ll highlight activity for ${storeName}.`
               : `Get notified about new deals and restocks at ${storeName}.`}
@@ -151,7 +171,7 @@ export default function StoreAlertSubscribe({
       {subscribed && (
         <p className="text-[11px] text-green-700 font-medium mt-2">Active · store alerts on</p>
       )}
-      {!subscribed && session && (
+      {!subscribed && (
         <p className="text-[11px] text-gray-400 mt-2">Inactive · not following this store</p>
       )}
       {error && (

--- a/components/StoreAlertSubscribe.tsx
+++ b/components/StoreAlertSubscribe.tsx
@@ -10,6 +10,8 @@ type Props = {
   storeName: string;
   /** Server-known active store_follow subscription */
   initialSubscribed: boolean;
+  /** Active store_follow alert row id when subscribed (avoids GET before DELETE) */
+  initialStoreFollowAlertId: string | null;
   /** From server auth() — client useSession can lag behind this */
   viewerRole: ViewerRole;
 };
@@ -18,18 +20,22 @@ export default function StoreAlertSubscribe({
   storeId,
   storeName,
   initialSubscribed,
+  initialStoreFollowAlertId,
   viewerRole,
 }: Props) {
   const router = useRouter();
   // Must match server on first paint — do not read sessionStorage here (hydration error).
   const [subscribed, setSubscribed] = useState(initialSubscribed);
+  const [followAlertId, setFollowAlertId] = useState<string | null>(
+    initialStoreFollowAlertId,
+  );
   const [pending, setPending] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  // When user unsubscribes elsewhere (e.g. My alerts) or server data updates, follow the server.
   useEffect(() => {
     setSubscribed(initialSubscribed);
-  }, [initialSubscribed, storeId]);
+    setFollowAlertId(initialStoreFollowAlertId);
+  }, [initialSubscribed, initialStoreFollowAlertId, storeId]);
 
   const callbackPath = `/stores/${storeId}`;
   const loginHref = `/login?callbackUrl=${encodeURIComponent(callbackPath)}`;
@@ -54,11 +60,12 @@ export default function StoreAlertSubscribe({
         });
         const payload = (await res.json().catch(() => ({}))) as {
           error?: string;
-          isActive?: boolean;
+          id?: string;
         };
 
         if (!res.ok) {
           setSubscribed(false);
+          setFollowAlertId(null);
           setError(
             typeof payload.error === "string"
               ? payload.error
@@ -72,8 +79,12 @@ export default function StoreAlertSubscribe({
         }
 
         setSubscribed(true);
+        setFollowAlertId(
+          typeof payload.id === "string" && payload.id ? payload.id : null,
+        );
       } catch {
         setSubscribed(false);
+        setFollowAlertId(null);
         setError("Network error — check your connection and try again.");
       } finally {
         setPending(false);
@@ -84,24 +95,30 @@ export default function StoreAlertSubscribe({
     setSubscribed(false);
     setPending(true);
     try {
-      const listRes = await fetch("/api/alerts", { credentials: "include" });
-      if (!listRes.ok) {
-        setSubscribed(true);
-        setError("Could not update subscription.");
-        return;
+      let alertId = followAlertId;
+      if (!alertId) {
+        const listRes = await fetch("/api/alerts", { credentials: "include" });
+        if (!listRes.ok) {
+          setSubscribed(true);
+          setError("Could not update subscription.");
+          return;
+        }
+        const data = (await listRes.json()) as {
+          alerts?: Array<{ id: string; type: string; storeId: string | null }>;
+        };
+        const row = (data.alerts ?? []).find(
+          (a) => a.type === "store_follow" && a.storeId === storeId,
+        );
+        if (!row) {
+          setFollowAlertId(null);
+          setSubscribed(false);
+          router.refresh();
+          return;
+        }
+        alertId = row.id;
       }
-      const data = (await listRes.json()) as {
-        alerts?: Array<{ id: string; type: string; storeId: string | null }>;
-      };
-      const row = (data.alerts ?? []).find(
-        (a) => a.type === "store_follow" && a.storeId === storeId,
-      );
-      if (!row) {
-        setSubscribed(false);
-        router.refresh();
-        return;
-      }
-      const del = await fetch(`/api/alerts/${row.id}`, {
+
+      const del = await fetch(`/api/alerts/${alertId}`, {
         method: "DELETE",
         credentials: "include",
       });
@@ -110,6 +127,7 @@ export default function StoreAlertSubscribe({
         setError("Could not unsubscribe.");
         return;
       }
+      setFollowAlertId(null);
       setSubscribed(false);
       router.refresh();
     } finally {

--- a/components/StoreAlertSubscribe.tsx
+++ b/components/StoreAlertSubscribe.tsx
@@ -1,0 +1,164 @@
+"use client";
+
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { useSession } from "next-auth/react";
+import { useState } from "react";
+
+type Props = {
+  storeId: string;
+  storeName: string;
+  /** Server-known active store_follow subscription */
+  initialSubscribed: boolean;
+};
+
+export default function StoreAlertSubscribe({
+  storeId,
+  storeName,
+  initialSubscribed,
+}: Props) {
+  const router = useRouter();
+  const { data: session, status } = useSession();
+  const [subscribed, setSubscribed] = useState(initialSubscribed);
+  const [pending, setPending] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const callbackPath = `/stores/${storeId}`;
+  const loginHref = `/login?callbackUrl=${encodeURIComponent(callbackPath)}`;
+  const signupHref = `/signup/shopper?callbackUrl=${encodeURIComponent(callbackPath)}`;
+
+  async function toggle() {
+    setError(null);
+    if (status !== "authenticated" || session?.role !== "shopper") {
+      router.push(loginHref);
+      return;
+    }
+
+    if (!subscribed) {
+      setSubscribed(true);
+      setPending(true);
+      const res = await fetch("/api/alerts", {
+        method: "POST",
+        credentials: "include",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ type: "store_follow", storeId }),
+      });
+      setPending(false);
+      if (!res.ok) {
+        setSubscribed(false);
+        const d = (await res.json().catch(() => ({}))) as { error?: string };
+        setError(d.error ?? "Could not subscribe.");
+      }
+      router.refresh();
+      return;
+    }
+
+    setSubscribed(false);
+    setPending(true);
+    const listRes = await fetch("/api/alerts", { credentials: "include" });
+    if (!listRes.ok) {
+      setSubscribed(true);
+      setPending(false);
+      setError("Could not update subscription.");
+      return;
+    }
+    const data = (await listRes.json()) as {
+      alerts?: Array<{ id: string; type: string; storeId: string | null }>;
+    };
+    const row = (data.alerts ?? []).find(
+      (a) => a.type === "store_follow" && a.storeId === storeId,
+    );
+    if (!row) {
+      setPending(false);
+      router.refresh();
+      return;
+    }
+    const del = await fetch(`/api/alerts/${row.id}`, {
+      method: "DELETE",
+      credentials: "include",
+    });
+    setPending(false);
+    if (!del.ok) {
+      setSubscribed(true);
+      setError("Could not unsubscribe.");
+      return;
+    }
+    router.refresh();
+  }
+
+  if (status === "loading") {
+    return (
+      <div className="rounded-xl border border-gray-100 bg-gray-50 px-4 py-3 text-[13px] text-gray-400">
+        Checking alerts…
+      </div>
+    );
+  }
+
+  if (session?.role === "owner") {
+    return null;
+  }
+
+  if (status !== "authenticated") {
+    return (
+      <div className="rounded-xl border border-amber-100 bg-amber-50/80 px-4 py-3">
+        <p className="text-[14px] text-amber-950 font-medium">
+          Get deals &amp; restocks from {storeName}
+        </p>
+        <p className="text-[13px] text-amber-900/80 mt-1">
+          <Link href={loginHref} className="font-semibold text-green-700 hover:underline">
+            Sign in
+          </Link>{" "}
+          or{" "}
+          <Link href={signupHref} className="font-semibold text-green-700 hover:underline">
+            create a free shopper account
+          </Link>{" "}
+          to subscribe — you&apos;ll return here after.
+        </p>
+      </div>
+    );
+  }
+
+  if (session.role !== "shopper") {
+    return null;
+  }
+
+  return (
+    <div className="rounded-xl border border-gray-200 bg-white px-4 py-3">
+      <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
+        <div>
+          <p className="text-[14px] font-semibold text-gray-800">
+            {subscribed ? "You’re subscribed" : "Follow this store"}
+          </p>
+          <p className="text-[13px] text-gray-500 mt-0.5">
+            {subscribed
+              ? `We’ll highlight activity for ${storeName}.`
+              : `Get notified about new deals and restocks at ${storeName}.`}
+          </p>
+        </div>
+        <button
+          type="button"
+          disabled={pending}
+          onClick={toggle}
+          className={`shrink-0 px-4 py-2 rounded-lg text-[13px] font-semibold transition-colors disabled:opacity-60 ${
+            subscribed
+              ? "border border-gray-200 text-gray-700 hover:bg-gray-50"
+              : "bg-green-600 text-white hover:bg-green-800"
+          }`}
+        >
+          {pending ? "…" : subscribed ? "Unsubscribe" : "Subscribe"}
+        </button>
+      </div>
+      {subscribed && (
+        <p className="text-[11px] text-green-700 font-medium mt-2">Active · store alerts on</p>
+      )}
+      {!subscribed && session && (
+        <p className="text-[11px] text-gray-400 mt-2">Inactive · not following this store</p>
+      )}
+      {error && (
+        <p className="text-[12px] text-red-700 mt-2" role="alert">
+          {error}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/lib/authenticate-shopper.ts
+++ b/lib/authenticate-shopper.ts
@@ -1,0 +1,34 @@
+import bcrypt from "bcryptjs";
+import { prisma } from "@/lib/prisma";
+
+export type ShopperAuthUser = {
+  id: string;
+  email: string;
+  name: string;
+};
+
+/**
+ * Validates email/password against shoppers (for Auth.js + tests).
+ */
+export async function authenticateShopper(
+  email: string | undefined,
+  password: string | undefined,
+): Promise<ShopperAuthUser | null> {
+  if (!email || !password) return null;
+
+  const normalized = email.trim().toLowerCase();
+  const shopper = await prisma.shopper.findUnique({
+    where: { email: normalized },
+  });
+
+  if (!shopper) return null;
+
+  const valid = await bcrypt.compare(password, shopper.passwordHash);
+  if (!valid) return null;
+
+  return {
+    id: shopper.id,
+    email: shopper.email,
+    name: shopper.name,
+  };
+}

--- a/lib/notify-store-followers.ts
+++ b/lib/notify-store-followers.ts
@@ -15,6 +15,41 @@ function formatPrice(price: Prisma.Decimal | null): string | null {
   }).format(n);
 }
 
+async function activeStoreFollowShopperIds(storeId: string): Promise<string[]> {
+  const rows = await prisma.alert.findMany({
+    where: {
+      type: AlertType.store_follow,
+      storeId,
+      isActive: true,
+    },
+    select: { shopperId: true },
+    distinct: ["shopperId"],
+  });
+  return rows.map((r) => r.shopperId);
+}
+
+async function insertNotificationsForFollowers(
+  storeId: string,
+  kind: ShopperNotificationKind,
+  sourceId: string,
+  title: string,
+  body: string | null,
+  shopperIds: string[],
+) {
+  if (shopperIds.length === 0) return;
+  await prisma.shopperNotification.createMany({
+    data: shopperIds.map((shopperId) => ({
+      shopperId,
+      kind,
+      sourceId,
+      storeId,
+      title,
+      body,
+    })),
+    skipDuplicates: true,
+  });
+}
+
 /**
  * Fan-out in-app notifications to shoppers with an active store_follow for this store.
  * Errors are logged; callers should not fail the owner action if this fails.
@@ -27,17 +62,7 @@ export async function notifyStoreFollowersOfFreshUpdate(params: {
   note: string | null;
 }) {
   try {
-    const followers = await prisma.alert.findMany({
-      where: {
-        type: AlertType.store_follow,
-        storeId: params.storeId,
-        isActive: true,
-      },
-      select: { shopperId: true },
-      distinct: ["shopperId"],
-    });
-    if (followers.length === 0) return;
-
+    const shopperIds = await activeStoreFollowShopperIds(params.storeId);
     const title = `Fresh update · ${params.storeName}`;
     const trimmedNote = params.note?.trim();
     const body =
@@ -45,17 +70,14 @@ export async function notifyStoreFollowersOfFreshUpdate(params: {
         ? `${params.itemName} — ${trimmedNote}`
         : params.itemName;
 
-    await prisma.shopperNotification.createMany({
-      data: followers.map((f) => ({
-        shopperId: f.shopperId,
-        kind: ShopperNotificationKind.store_fresh_update,
-        sourceId: params.freshUpdateId,
-        storeId: params.storeId,
-        title,
-        body,
-      })),
-      skipDuplicates: true,
-    });
+    await insertNotificationsForFollowers(
+      params.storeId,
+      ShopperNotificationKind.store_fresh_update,
+      params.freshUpdateId,
+      title,
+      body,
+      shopperIds,
+    );
   } catch (e) {
     console.error("notifyStoreFollowersOfFreshUpdate:", e);
   }
@@ -69,34 +91,21 @@ export async function notifyStoreFollowersOfNewDeal(params: {
   price: Prisma.Decimal | null;
 }) {
   try {
-    const followers = await prisma.alert.findMany({
-      where: {
-        type: AlertType.store_follow,
-        storeId: params.storeId,
-        isActive: true,
-      },
-      select: { shopperId: true },
-      distinct: ["shopperId"],
-    });
-    if (followers.length === 0) return;
-
+    const shopperIds = await activeStoreFollowShopperIds(params.storeId);
     const priceLabel = formatPrice(params.price);
     const title = `New deal · ${params.storeName}`;
     const body = priceLabel
       ? `${params.dealTitle} · ${priceLabel}`
       : params.dealTitle;
 
-    await prisma.shopperNotification.createMany({
-      data: followers.map((f) => ({
-        shopperId: f.shopperId,
-        kind: ShopperNotificationKind.store_new_deal,
-        sourceId: params.dealId,
-        storeId: params.storeId,
-        title,
-        body,
-      })),
-      skipDuplicates: true,
-    });
+    await insertNotificationsForFollowers(
+      params.storeId,
+      ShopperNotificationKind.store_new_deal,
+      params.dealId,
+      title,
+      body,
+      shopperIds,
+    );
   } catch (e) {
     console.error("notifyStoreFollowersOfNewDeal:", e);
   }

--- a/lib/notify-store-followers.ts
+++ b/lib/notify-store-followers.ts
@@ -1,0 +1,103 @@
+import {
+  AlertType,
+  Prisma,
+  ShopperNotificationKind,
+} from "@/app/generated/prisma/client";
+import { prisma } from "@/lib/prisma";
+
+function formatPrice(price: Prisma.Decimal | null): string | null {
+  if (price == null) return null;
+  const n = Number(price);
+  if (!Number.isFinite(n)) return null;
+  return new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "USD",
+  }).format(n);
+}
+
+/**
+ * Fan-out in-app notifications to shoppers with an active store_follow for this store.
+ * Errors are logged; callers should not fail the owner action if this fails.
+ */
+export async function notifyStoreFollowersOfFreshUpdate(params: {
+  storeId: string;
+  storeName: string;
+  freshUpdateId: string;
+  itemName: string;
+  note: string | null;
+}) {
+  try {
+    const followers = await prisma.alert.findMany({
+      where: {
+        type: AlertType.store_follow,
+        storeId: params.storeId,
+        isActive: true,
+      },
+      select: { shopperId: true },
+      distinct: ["shopperId"],
+    });
+    if (followers.length === 0) return;
+
+    const title = `Fresh update · ${params.storeName}`;
+    const trimmedNote = params.note?.trim();
+    const body =
+      trimmedNote && trimmedNote.length > 0
+        ? `${params.itemName} — ${trimmedNote}`
+        : params.itemName;
+
+    await prisma.shopperNotification.createMany({
+      data: followers.map((f) => ({
+        shopperId: f.shopperId,
+        kind: ShopperNotificationKind.store_fresh_update,
+        sourceId: params.freshUpdateId,
+        storeId: params.storeId,
+        title,
+        body,
+      })),
+      skipDuplicates: true,
+    });
+  } catch (e) {
+    console.error("notifyStoreFollowersOfFreshUpdate:", e);
+  }
+}
+
+export async function notifyStoreFollowersOfNewDeal(params: {
+  storeId: string;
+  storeName: string;
+  dealId: string;
+  dealTitle: string;
+  price: Prisma.Decimal | null;
+}) {
+  try {
+    const followers = await prisma.alert.findMany({
+      where: {
+        type: AlertType.store_follow,
+        storeId: params.storeId,
+        isActive: true,
+      },
+      select: { shopperId: true },
+      distinct: ["shopperId"],
+    });
+    if (followers.length === 0) return;
+
+    const priceLabel = formatPrice(params.price);
+    const title = `New deal · ${params.storeName}`;
+    const body = priceLabel
+      ? `${params.dealTitle} · ${priceLabel}`
+      : params.dealTitle;
+
+    await prisma.shopperNotification.createMany({
+      data: followers.map((f) => ({
+        shopperId: f.shopperId,
+        kind: ShopperNotificationKind.store_new_deal,
+        sourceId: params.dealId,
+        storeId: params.storeId,
+        title,
+        body,
+      })),
+      skipDuplicates: true,
+    });
+  } catch (e) {
+    console.error("notifyStoreFollowersOfNewDeal:", e);
+  }
+}

--- a/lib/require-shopper.ts
+++ b/lib/require-shopper.ts
@@ -1,0 +1,17 @@
+import { NextResponse } from "next/server";
+import { auth } from "@/auth";
+
+export async function requireShopperSession() {
+  const session = await auth();
+  if (!session?.user?.id) {
+    return {
+      response: NextResponse.json({ error: "Unauthorized" }, { status: 401 }),
+    };
+  }
+  if (session.role !== "shopper") {
+    return {
+      response: NextResponse.json({ error: "Forbidden" }, { status: 403 }),
+    };
+  }
+  return { session, shopperId: session.user.id };
+}

--- a/lib/safe-callback-path.test.ts
+++ b/lib/safe-callback-path.test.ts
@@ -16,6 +16,11 @@ describe("safeCallbackPath", () => {
     assert.equal(safeCallbackPath("/dashboard"), "/dashboard");
     assert.equal(safeCallbackPath(" /profile "), "/profile");
   });
+
+  it("uses custom default for missing values", () => {
+    assert.equal(safeCallbackPath(null, "/"), "/");
+    assert.equal(safeCallbackPath("//evil", "/"), "/");
+  });
 });
 
 describe("safeRedirectPathForClient", () => {

--- a/lib/safe-callback-path.ts
+++ b/lib/safe-callback-path.ts
@@ -2,10 +2,14 @@
  * Accepts only same-app relative paths for post-login redirects.
  * Rejects protocol-relative URLs (`//…`) and non-path values.
  */
-export function safeCallbackPath(raw: string | null | undefined): string {
-  if (raw == null || raw === "") return "/dashboard";
+export function safeCallbackPath(
+  raw: string | null | undefined,
+  /** When missing or unsafe (store owners default to dashboard; shoppers often `/`). */
+  defaultPath = "/dashboard",
+): string {
+  if (raw == null || raw === "") return defaultPath;
   const t = raw.trim();
-  if (!isSafeRelativeAppPath(t)) return "/dashboard";
+  if (!isSafeRelativeAppPath(t)) return defaultPath;
   return t;
 }
 

--- a/lib/validate-shopper-signup.ts
+++ b/lib/validate-shopper-signup.ts
@@ -1,0 +1,79 @@
+import { safeCallbackPath } from "@/lib/safe-callback-path";
+
+export type ShopperSignupInput = {
+  email: string;
+  password: string;
+  name: string;
+  callbackUrl: string;
+};
+
+export type ShopperSignupValidationResult =
+  | { ok: true; data: ShopperSignupInput }
+  | { ok: false; errors: Record<string, string> };
+
+const EMAIL_RE =
+  /^[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$/;
+
+export function validateShopperSignup(body: unknown): ShopperSignupValidationResult {
+  if (!body || typeof body !== "object") {
+    return { ok: false, errors: { form: "Invalid JSON body." } };
+  }
+
+  const input = body as Record<string, unknown>;
+  const errors: Record<string, string> = {};
+
+  const rawName = typeof input.name === "string" ? input.name.trim() : "";
+  if (!rawName) {
+    errors.name = "Name is required.";
+  } else if (rawName.length > 120) {
+    errors.name = "Name must be at most 120 characters.";
+  }
+
+  const rawEmail =
+    typeof input.email === "string" ? input.email.trim().toLowerCase() : "";
+  if (!rawEmail) {
+    errors.email = "Email is required.";
+  } else if (!EMAIL_RE.test(rawEmail)) {
+    errors.email = "Enter a valid email address.";
+  }
+
+  const password = typeof input.password === "string" ? input.password : "";
+  if (!password) {
+    errors.password = "Password is required.";
+  } else {
+    const pwdReqs: string[] = [];
+    if (password.length < 8) pwdReqs.push("be at least 8 characters");
+    if (!/[a-zA-Z]/.test(password)) pwdReqs.push("include at least one letter");
+    if (!/[0-9]/.test(password)) pwdReqs.push("include at least one number");
+    if (pwdReqs.length) {
+      errors.password = `Password must ${pwdReqs.join(", ")}.`;
+    }
+  }
+
+  const confirmPassword =
+    typeof input.confirmPassword === "string" ? input.confirmPassword : "";
+  if (!confirmPassword) {
+    errors.confirmPassword = "Confirm your password.";
+  } else if (confirmPassword !== password) {
+    errors.confirmPassword = "Passwords do not match.";
+  }
+
+  const callbackUrl = safeCallbackPath(
+    typeof input.callbackUrl === "string" ? input.callbackUrl : undefined,
+    "/",
+  );
+
+  if (Object.keys(errors).length > 0) {
+    return { ok: false, errors };
+  }
+
+  return {
+    ok: true,
+    data: {
+      email: rawEmail,
+      password,
+      name: rawName,
+      callbackUrl,
+    },
+  };
+}

--- a/lib/viewer-role.ts
+++ b/lib/viewer-role.ts
@@ -1,0 +1,2 @@
+/** Resolved on the server via `auth()` and passed into client island components. */
+export type ViewerRole = "shopper" | "owner" | null;

--- a/middleware.ts
+++ b/middleware.ts
@@ -11,6 +11,11 @@ export async function middleware(req: NextRequest) {
     return NextResponse.redirect(loginUrl);
   }
 
+  const role = token.role as string | undefined;
+  if (role === "shopper") {
+    return NextResponse.redirect(new URL("/", req.url));
+  }
+
   return NextResponse.next();
 }
 

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "test:geocode": "tsx scripts/geocode-branch-tests.ts",
     "test:store-profile": "tsx scripts/store-profile-machine-tests.ts",
     "test:fresh-updates": "node --import tsx --test lib/fresh-updates.test.ts",
-    "test:fresh-updates-machine": "tsx scripts/fresh-updates-machine-tests.ts"
+    "test:fresh-updates-machine": "tsx scripts/fresh-updates-machine-tests.ts",
+    "test:alerts-machine": "tsx scripts/alerts-machine-tests.ts"
   },
   "dependencies": {
     "@prisma/adapter-pg": "^7.5.0",

--- a/prisma/fixtures.ts
+++ b/prisma/fixtures.ts
@@ -13,7 +13,14 @@ export const fixtureMeta = {
   baseTime: BASE_TIME,
   publicNowHint: "2026-03-20T16:00:00.000Z",
   ownerPlaintextPassword: "OwnerPass123!",
+  /** Fixture logins for seeded shoppers (`authenticateShopper` / NextAuth) */
+  shopperPlaintextPassword: "ShopperPass123!",
 };
+
+const shopperFixturePasswordHash = bcrypt.hashSync(
+  fixtureMeta.shopperPlaintextPassword,
+  BCRYPT_SALT,
+);
 
 export const ids = {
   owners: {
@@ -229,72 +236,84 @@ export const shoppers = [
     id: ids.shoppers.nina,
     email: "nina.shopper@testmail.com",
     name: "Nina Shopper",
+    passwordHash: shopperFixturePasswordHash,
     createdAt: atDays(-10),
   },
   {
     id: ids.shoppers.jordan,
     email: "jordan.shopper@testmail.com",
     name: "Jordan Shopper",
+    passwordHash: shopperFixturePasswordHash,
     createdAt: atDays(-8),
   },
   {
     id: ids.shoppers.shopper03,
     email: "alex.shopper@testmail.com",
     name: "Alex Shopper",
+    passwordHash: shopperFixturePasswordHash,
     createdAt: atDays(-7),
   },
   {
     id: ids.shoppers.shopper04,
     email: "taylor.shopper@testmail.com",
     name: "Taylor Shopper",
+    passwordHash: shopperFixturePasswordHash,
     createdAt: atDays(-6),
   },
   {
     id: ids.shoppers.shopper05,
     email: "sam.shopper@testmail.com",
     name: "Sam Shopper",
+    passwordHash: shopperFixturePasswordHash,
     createdAt: atDays(-6),
   },
   {
     id: ids.shoppers.shopper06,
     email: "riley.shopper@testmail.com",
     name: "Riley Shopper",
+    passwordHash: shopperFixturePasswordHash,
     createdAt: atDays(-5),
   },
   {
     id: ids.shoppers.shopper07,
     email: "morgan.shopper@testmail.com",
     name: "Morgan Shopper",
+    passwordHash: shopperFixturePasswordHash,
     createdAt: atDays(-5),
   },
   {
     id: ids.shoppers.shopper08,
     email: "jamie.shopper@testmail.com",
     name: "Jamie Shopper",
+    passwordHash: shopperFixturePasswordHash,
     createdAt: atDays(-4),
   },
   {
     id: ids.shoppers.shopper09,
     email: "drew.shopper@testmail.com",
     name: "Drew Shopper",
+    passwordHash: shopperFixturePasswordHash,
     createdAt: atDays(-4),
   },
   {
     id: ids.shoppers.shopper10,
     email: "casey.shopper2@testmail.com",
     name: "Casey Shopper",
+    passwordHash: shopperFixturePasswordHash,
     createdAt: atDays(-3),
   },
   {
     id: ids.shoppers.shopper11,
     email: "cameron.shopper@testmail.com",
     name: "Cameron Shopper",
+    passwordHash: shopperFixturePasswordHash,
     createdAt: atDays(-3),
   },
   {
     id: ids.shoppers.shopper12,
     email: "peyton.shopper@testmail.com",
     name: "Peyton Shopper",
+    passwordHash: shopperFixturePasswordHash,
     createdAt: atDays(-2),
   },
 ];

--- a/prisma/migrations/20260325120000_enable_rls_all_tables/migration.sql
+++ b/prisma/migrations/20260325120000_enable_rls_all_tables/migration.sql
@@ -1,0 +1,14 @@
+-- Enable Row Level Security on all app tables (Supabase-friendly baseline).
+-- If `prisma migrate status` reports a checksum mismatch, the SQL here differs
+-- from what was applied on your database. Replace this file with the exact
+-- migration from whoever ran it, or recover from `_prisma_migrations` / SQL history.
+
+ALTER TABLE "store_owners" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "password_reset_tokens" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "stores" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "items" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "fresh_updates" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "deals" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "owner_notifications" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "shoppers" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "alerts" ENABLE ROW LEVEL SECURITY;

--- a/prisma/migrations/20260325120000_shopper_password_hash/migration.sql
+++ b/prisma/migrations/20260325120000_shopper_password_hash/migration.sql
@@ -1,8 +1,0 @@
--- AlterTable
-ALTER TABLE "shoppers" ADD COLUMN "password_hash" TEXT;
-
-UPDATE "shoppers"
-SET "password_hash" = '$2b$10$CwTycUXWue0Thq9StjUM0u1lv/4XmMKL8gwniPoRzozifdDxblDmq'
-WHERE "password_hash" IS NULL;
-
-ALTER TABLE "shoppers" ALTER COLUMN "password_hash" SET NOT NULL;

--- a/prisma/migrations/20260325120000_shopper_password_hash/migration.sql
+++ b/prisma/migrations/20260325120000_shopper_password_hash/migration.sql
@@ -1,0 +1,8 @@
+-- AlterTable
+ALTER TABLE "shoppers" ADD COLUMN "password_hash" TEXT;
+
+UPDATE "shoppers"
+SET "password_hash" = '$2b$10$CwTycUXWue0Thq9StjUM0u1lv/4XmMKL8gwniPoRzozifdDxblDmq'
+WHERE "password_hash" IS NULL;
+
+ALTER TABLE "shoppers" ALTER COLUMN "password_hash" SET NOT NULL;

--- a/prisma/migrations/20260326120000_shopper_password_hash/migration.sql
+++ b/prisma/migrations/20260326120000_shopper_password_hash/migration.sql
@@ -1,0 +1,8 @@
+-- AlterTable
+ALTER TABLE "shoppers" ADD COLUMN "password_hash" TEXT;
+
+-- Backfill existing rows (seed replaces these; invalid placeholder until re-seed)
+UPDATE "shoppers" SET "password_hash" = '$2a$12$vI8aWBnW3fID.ZQ4/zo1G.q1lRps.9cGLcZEiGDMVr5yUP1KUOYTa'
+WHERE "password_hash" IS NULL;
+
+ALTER TABLE "shoppers" ALTER COLUMN "password_hash" SET NOT NULL;

--- a/prisma/migrations/20260327120000_shopper_notifications/migration.sql
+++ b/prisma/migrations/20260327120000_shopper_notifications/migration.sql
@@ -1,0 +1,31 @@
+-- CreateEnum
+CREATE TYPE "ShopperNotificationKind" AS ENUM ('store_fresh_update', 'store_new_deal');
+
+-- CreateTable
+CREATE TABLE "shopper_notifications" (
+    "id" TEXT NOT NULL,
+    "shopper_id" TEXT NOT NULL,
+    "kind" "ShopperNotificationKind" NOT NULL,
+    "source_id" TEXT NOT NULL,
+    "store_id" TEXT NOT NULL,
+    "title" TEXT NOT NULL,
+    "body" TEXT,
+    "read_at" TIMESTAMP(3),
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "shopper_notifications_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "shopper_notifications_shopper_id_kind_source_id_key" ON "shopper_notifications"("shopper_id", "kind", "source_id");
+
+-- CreateIndex
+CREATE INDEX "shopper_notifications_shopper_id_created_at_idx" ON "shopper_notifications"("shopper_id", "created_at" DESC);
+
+-- AddForeignKey
+ALTER TABLE "shopper_notifications" ADD CONSTRAINT "shopper_notifications_shopper_id_fkey" FOREIGN KEY ("shopper_id") REFERENCES "shoppers"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "shopper_notifications" ADD CONSTRAINT "shopper_notifications_store_id_fkey" FOREIGN KEY ("store_id") REFERENCES "stores"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+ALTER TABLE "shopper_notifications" ENABLE ROW LEVEL SECURITY;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -132,10 +132,11 @@ model OwnerNotification {
 }
 
 model Shopper {
-  id        String   @id @default(uuid())
-  email     String   @unique
-  name      String
-  createdAt DateTime @default(now()) @map("created_at")
+  id           String   @id @default(uuid())
+  email        String   @unique
+  name         String
+  passwordHash String   @map("password_hash")
+  createdAt    DateTime @default(now()) @map("created_at")
 
   alerts Alert[]
 

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -12,6 +12,11 @@ enum AlertType {
   store_follow
 }
 
+enum ShopperNotificationKind {
+  store_fresh_update
+  store_new_deal
+}
+
 model StoreOwner {
   id           String   @id @default(uuid())
   email        String   @unique
@@ -55,7 +60,8 @@ model Store {
   items        Item[]
   freshUpdates FreshUpdate[]
   deals        Deal[]
-  alerts       Alert[]
+  alerts               Alert[]
+  shopperNotifications ShopperNotification[]
 
   @@map("stores")
 }
@@ -138,9 +144,29 @@ model Shopper {
   passwordHash String   @map("password_hash")
   createdAt    DateTime @default(now()) @map("created_at")
 
-  alerts Alert[]
+  alerts               Alert[]
+  notifications        ShopperNotification[]
 
   @@map("shoppers")
+}
+
+model ShopperNotification {
+  id         String                  @id @default(uuid())
+  shopperId  String                  @map("shopper_id")
+  kind       ShopperNotificationKind
+  sourceId   String                  @map("source_id")
+  storeId    String                  @map("store_id")
+  title      String
+  body       String?
+  readAt     DateTime?               @map("read_at")
+  createdAt  DateTime                @default(now()) @map("created_at")
+
+  shopper Shopper @relation(fields: [shopperId], references: [id], onDelete: Cascade)
+  store   Store   @relation(fields: [storeId], references: [id], onDelete: Cascade)
+
+  @@unique([shopperId, kind, sourceId])
+  @@index([shopperId, createdAt(sort: Desc)])
+  @@map("shopper_notifications")
 }
 
 model Alert {

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -49,6 +49,7 @@ async function main() {
   console.log("Deterministic GrocerEase test data seeded.");
   console.log(`Seed clock: ${fixtureMeta.baseTime.toISOString()}`);
   console.log(`Owner login password (fixtures): ${fixtureMeta.ownerPlaintextPassword}`);
+  console.log(`Shopper login password (fixtures): ${fixtureMeta.shopperPlaintextPassword}`);
 }
 
 main()

--- a/scripts/alerts-machine-tests.ts
+++ b/scripts/alerts-machine-tests.ts
@@ -1,0 +1,114 @@
+import "dotenv/config";
+import { strict as assert } from "node:assert";
+import { fixtureMeta, ids } from "../prisma/fixtures";
+
+const BASE = process.env.TEST_BASE_URL ?? "http://localhost:3000";
+const SHOPPER_EMAIL = "nina.shopper@testmail.com";
+const SHOPPER_PASSWORD = fixtureMeta.shopperPlaintextPassword;
+const STORE_ID = ids.stores.lotus;
+const ITEM_ID = ids.items.bokChoy;
+
+function cookiePairHeader(setCookieLines: string[]): string {
+  return setCookieLines
+    .map((line) => line.split(";")[0]?.trim())
+    .filter(Boolean)
+    .join("; ");
+}
+
+async function loginShopper() {
+  const res = await fetch(`${BASE}/auth/login`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      email: SHOPPER_EMAIL,
+      password: SHOPPER_PASSWORD,
+      callbackUrl: "/",
+    }),
+  });
+  const setCookies = res.headers.getSetCookie?.() ?? [];
+  return { res, cookieHeader: cookiePairHeader(setCookies) };
+}
+
+async function main() {
+  const { res: loginRes, cookieHeader } = await loginShopper();
+  assert.equal(loginRes.status, 200, "Shopper login should succeed");
+  assert.ok(cookieHeader, "Expected session cookie from /auth/login");
+
+  const headersJson = {
+    "Content-Type": "application/json",
+    Cookie: cookieHeader,
+  };
+
+  // POST store_follow
+  const follow = await fetch(`${BASE}/api/alerts`, {
+    method: "POST",
+    headers: headersJson,
+    body: JSON.stringify({ type: "store_follow", storeId: STORE_ID }),
+  });
+  assert.equal(follow.status, 201, "POST store_follow should return 201");
+  const followBody = (await follow.json()) as { type: string; storeId: string | null };
+  assert.equal(followBody.type, "store_follow");
+  assert.equal(followBody.storeId, STORE_ID);
+
+  // POST item_restock
+  const restock = await fetch(`${BASE}/api/alerts`, {
+    method: "POST",
+    headers: headersJson,
+    body: JSON.stringify({
+      type: "item_restock",
+      storeId: STORE_ID,
+      itemId: ITEM_ID,
+    }),
+  });
+  assert.equal(restock.status, 201, "POST item_restock should return 201");
+  const restockBody = (await restock.json()) as { type: string; itemId: string | null };
+  assert.equal(restockBody.type, "item_restock");
+  assert.equal(restockBody.itemId, ITEM_ID);
+
+  // GET active alerts
+  const listRes = await fetch(`${BASE}/api/alerts`, {
+    headers: { Cookie: cookieHeader },
+  });
+  assert.equal(listRes.status, 200, "GET /api/alerts should return 200");
+  const list = (await listRes.json()) as {
+    alerts: Array<{ id: string; type: string; isActive: boolean }>;
+  };
+  assert.ok(Array.isArray(list.alerts), "Response should include alerts array");
+  assert.ok(
+    list.alerts.length >= 2,
+    "Should include at least the two alerts created in this run",
+  );
+  assert.ok(
+    list.alerts.every((a) => a.isActive),
+    "GET should only return active alerts",
+  );
+
+  const firstId = list.alerts[0]!.id;
+  const delRes = await fetch(`${BASE}/api/alerts/${firstId}`, {
+    method: "DELETE",
+    headers: { Cookie: cookieHeader },
+  });
+  assert.equal(delRes.status, 200, "DELETE should return 200");
+  const delBody = (await delRes.json()) as { isActive: boolean };
+  assert.equal(delBody.isActive, false);
+
+  const list2 = await fetch(`${BASE}/api/alerts`, {
+    headers: { Cookie: cookieHeader },
+  });
+  const list2Json = (await list2.json()) as { alerts: Array<{ id: string }> };
+  assert.ok(
+    !list2Json.alerts.some((a) => a.id === firstId),
+    "Soft-deleted alert should not appear in GET",
+  );
+
+  // Unauthorized without cookie
+  const anon = await fetch(`${BASE}/api/alerts`);
+  assert.equal(anon.status, 401, "GET without session should be 401");
+
+  console.log("All shopper alerts machine checks passed.");
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exitCode = 1;
+});

--- a/scripts/alerts-machine-tests.ts
+++ b/scripts/alerts-machine-tests.ts
@@ -39,6 +39,36 @@ async function main() {
     Cookie: cookieHeader,
   };
 
+  // POST validation (acceptance criteria)
+  const noStoreFollow = await fetch(`${BASE}/api/alerts`, {
+    method: "POST",
+    headers: headersJson,
+    body: JSON.stringify({ type: "store_follow" }),
+  });
+  assert.equal(noStoreFollow.status, 400, "store_follow without storeId should be 400");
+
+  const noItemRestock = await fetch(`${BASE}/api/alerts`, {
+    method: "POST",
+    headers: headersJson,
+    body: JSON.stringify({ type: "item_restock", storeId: STORE_ID }),
+  });
+  assert.equal(
+    noItemRestock.status,
+    400,
+    "item_restock without itemId should be 400",
+  );
+
+  const noStoreItemRestock = await fetch(`${BASE}/api/alerts`, {
+    method: "POST",
+    headers: headersJson,
+    body: JSON.stringify({ type: "item_restock", itemId: ITEM_ID }),
+  });
+  assert.equal(
+    noStoreItemRestock.status,
+    400,
+    "item_restock without storeId should be 400",
+  );
+
   // POST store_follow
   const follow = await fetch(`${BASE}/api/alerts`, {
     method: "POST",

--- a/types/next-auth.d.ts
+++ b/types/next-auth.d.ts
@@ -8,12 +8,19 @@ declare module "next-auth" {
       name: string;
     };
     storeId: string | null;
+    /** Present on new sessions; missing tokens default to `"owner"` in the session callback. */
+    role: "owner" | "shopper";
+  }
+
+  interface User {
+    role?: "owner" | "shopper";
+    storeId?: string | null;
   }
 }
 
 declare module "next-auth/jwt" {
   interface JWT {
-    ownerId: string;
     storeId: string | null;
+    role?: "owner" | "shopper";
   }
 }


### PR DESCRIPTION
## Summary

Closes #4 - Adds an **Activity** inbox on **My alerts** so shoppers see real updates from stores they follow (fresh posts and new deals), persisted in the database. Fan-out runs when owners create a **fresh update** or **deal**; followers with an active `store_follow` get an in-app notification (not email/push).
Fixes **Subscribe / Follow** visibility: removes client `sessionStorage` hydration mismatch, syncs subscription state from the server, adds a server-rendered **Follow this store** heading, and clarifies **guest** vs **owner** paths (owners use separate CTAs to act as a shopper). Extends **alerts machine tests** with POST validation cases.


## Acceptance criteria

 Human

- [x] Logged-in **shopper** sees **Subscribe** (or Unsubscribe) under **Follow this store** on a published store profile; guests see **Subscribe — log in** / **sign up**; **owners** see an explanation and shopper login/sign-up links instead of a blank gap.
- [x] **My alerts** shows **Activity** (inbox) above **Subscriptions**; new store posts/deals appear for users who follow that store.
- [x] **Mark read** moves an item to the **Read** section below unread; **Mark unread** moves it back up; unread stay sorted newest-first, then read newest-first.
- [x] Hard refresh / cross-tab session behavior matches expectations (same-browser cookies).

 Machine

- [x] `POST /api/stores/:id/updates` (owner) after creating a row notifies all active `store_follow` shoppers for that store (idempotent per shopper/update via unique key).
- [x] `POST /api/stores/:id/deals` (owner, both create paths) notifies followers similarly.
- [x] `GET /api/shopper/notifications` returns inbox for authenticated **shopper**; `PATCH /api/shopper/notifications/:id` toggles `readAt`.
- [x] `npm run test:alerts-machine` still passes (includes `store_follow` / `item_restock` validation).
- [x] `npx prisma migrate deploy` (or `migrate dev`) applies `20260327120000_shopper_notifications` on a DB whose migration history is consistent with the repo.

---

## Files changed

| Area | Files |
|------|--------|
| Schema & migration | `prisma/schema.prisma`, `prisma/migrations/20260327120000_shopper_notifications/migration.sql` |
| Fan-out | `lib/notify-store-followers.ts` |
| Owner APIs | `app/api/stores/[id]/updates/route.ts`, `app/api/stores/[id]/deals/route.ts` |
| Shopper inbox API | `app/api/shopper/notifications/route.ts`, `app/api/shopper/notifications/[id]/route.ts` |
| My alerts UI | `app/(public)/my-alerts/page.tsx`, `app/(public)/my-alerts/MyAlertsClient.tsx` |
| Store profile & subscribe | `app/(public)/stores/[id]/page.tsx`, `components/StoreAlertSubscribe.tsx` |
| Tests | `scripts/alerts-machine-tests.ts` |