### PR TITLE
Fix: mobile navbar overflow and harden post/deal update flows

### DIFF
--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -11,12 +11,12 @@ export default async function Navbar() {
   return (
     <header className="sticky top-0 z-50 border-b border-gray-200 bg-white">
       <nav
-        className="mx-auto flex items-center gap-0 px-6 h-[58px]"
+        className="mx-auto flex h-[58px] items-center gap-2 px-4 sm:px-6"
         aria-label="Main navigation"
       >
         <Link
           href="/"
-          className="font-display text-[22px] font-semibold text-green-600 tracking-tight mr-10 shrink-0"
+          className="font-display text-[20px] sm:text-[22px] font-semibold text-green-600 tracking-tight mr-2 sm:mr-10 shrink-0"
         >
           Local<span className="text-green-200">Grocer</span>
         </Link>
@@ -44,7 +44,7 @@ export default async function Navbar() {
         </div>
 
         {authed ? (
-          <div className="flex flex-wrap gap-2 items-center justify-end ml-auto">
+          <div className="hidden sm:flex flex-wrap gap-2 items-center justify-end ml-auto">
             {isOwner && (
               <Link
                 href="/dashboard"
@@ -64,7 +64,7 @@ export default async function Navbar() {
             <SignOutButton className="px-4 py-1.5 rounded-md text-sm font-medium text-gray-600 border border-gray-200 hover:bg-gray-100 transition-colors" />
           </div>
         ) : (
-          <div className="flex flex-wrap gap-2 items-center justify-end ml-auto">
+          <div className="hidden sm:flex flex-wrap gap-2 items-center justify-end ml-auto">
             <Link
               href="/shopper/login"
               className="px-4 py-1.5 rounded-md text-sm font-medium text-gray-600 border border-gray-200 hover:bg-gray-100 transition-colors"
@@ -82,6 +82,50 @@ export default async function Navbar() {
               className="px-4 py-1.5 rounded-md text-sm font-medium text-white bg-green-600 hover:bg-green-800 transition-colors"
             >
               List your store
+            </Link>
+          </div>
+        )}
+
+        {/* Compact mobile actions to avoid horizontal overflow */}
+        {authed ? (
+          <div className="sm:hidden ml-auto flex items-center gap-1.5 min-w-0">
+            {isOwner && (
+              <Link
+                href="/dashboard"
+                className="px-2.5 py-1 rounded-md text-xs font-medium text-white bg-green-600 hover:bg-green-800 transition-colors whitespace-nowrap"
+              >
+                Owner
+              </Link>
+            )}
+            {isShopper && (
+              <Link
+                href="/my-alerts"
+                className="px-2.5 py-1 rounded-md text-xs font-medium text-white bg-green-600 hover:bg-green-800 transition-colors whitespace-nowrap"
+              >
+                Alerts
+              </Link>
+            )}
+            <SignOutButton className="px-2.5 py-1 rounded-md text-xs font-medium text-gray-600 border border-gray-200 hover:bg-gray-100 transition-colors whitespace-nowrap" />
+          </div>
+        ) : (
+          <div className="sm:hidden ml-auto flex items-center gap-1.5 min-w-0">
+            <Link
+              href="/shopper/login"
+              className="px-2.5 py-1 rounded-md text-xs font-medium text-gray-600 border border-gray-200 hover:bg-gray-100 transition-colors whitespace-nowrap"
+            >
+              Shopper
+            </Link>
+            <Link
+              href="/login"
+              className="px-2.5 py-1 rounded-md text-xs font-medium text-gray-600 border border-gray-200 hover:bg-gray-100 transition-colors whitespace-nowrap"
+            >
+              Owner
+            </Link>
+            <Link
+              href="/signup"
+              className="px-2.5 py-1 rounded-md text-xs font-medium text-white bg-green-600 hover:bg-green-800 transition-colors whitespace-nowrap"
+            >
+              List
             </Link>
           </div>
         )}


### PR DESCRIPTION
## Summary
- Fix mobile navbar overflow by introducing compact mobile-only action controls in `Navbar`, while keeping full desktop actions unchanged.
- Improve real-time post feed behavior by preserving browser SSE auto-reconnect (remove manual close-on-error) and clarifying event semantics with `POST_CREATE`.
- Address review feedback in owner editing flows: prevent deal edit state corruption during saves and harden post/deal write paths using store-scoped update conditions.

## Changes included
- `components/Navbar.tsx`
  - Responsive layout cleanup for top nav.
  - Separate desktop (`sm+`) and compact mobile (`sm`) action groups.
  - Reduced mobile logo/action spacing and shorter labels to stay within viewport width.
- `components/StoreFreshUpdatesFeed.tsx`
  - Remove `EventSource` error handler that permanently closed the stream.
- `lib/post-events.ts`
  - Add `POST_CREATE` event type.
- `app/api/stores/[id]/updates/route.ts`
  - Emit `POST_CREATE` on new post creation.
- `app/(dashboard)/dashboard/deals/ManageDealsClient.tsx`
  - Disable deal `Edit` interactions while `savingEdit` is in-flight.
  - Guard `startEdit` during active save.
- `app/api/stores/[id]/posts/[postId]/route.ts`
  - Use store-scoped mutation constraints to avoid race-window writes.
- `app/api/stores/[id]/deals/[dealId]/route.ts`
  - Use store-scoped mutation constraints for PATCH/DELETE and preserve owner isolation.

## Why this PR
- Resolves a visible mobile UX bug where the navbar could render off-screen.
- Prevents real-time feed drops after transient network failures.
- Tightens event semantics for future consumers and observability.
- Reduces risk of cross-entity update races and UI edit-state corruption.

## Test plan
- [x] `npm run lint` (no new errors; existing unrelated warnings remain in `scripts/signup-machine-tests.ts`)
- [x] `npm run test:fresh-updates`
- [x] `npm run test:deals-machine`
- [x] Manual responsive check at 320px / 360px / 390px widths
- [x] Manual check: post create/edit/delete updates shopper feed without reload
- [x] Manual check: switching deal cards while save is pending no longer mutates wrong deal state