### PR TITLE
bug fix: website crash when searching

### DIFF
--- a/components/ItemAvailabilitySearch.tsx
+++ b/components/ItemAvailabilitySearch.tsx
@@ -15,6 +15,25 @@ type SearchResult = {
   last_updated: string;
 };
 
+type AlertRow = {
+  id: string;
+  itemId: string | null;
+  storeId: string | null;
+  type: string;
+};
+
+function normalizeAlertsPayload(payload: unknown): AlertRow[] {
+  if (Array.isArray(payload)) return payload as AlertRow[];
+  if (
+    payload &&
+    typeof payload === "object" &&
+    Array.isArray((payload as { alerts?: unknown }).alerts)
+  ) {
+    return (payload as { alerts: AlertRow[] }).alerts;
+  }
+  return [];
+}
+
 type Props = {
   storeId: string;
   storeName: string;
@@ -78,11 +97,7 @@ export default function ItemAvailabilitySearch({
       }
       setAuthRequired(false);
       if (!res.ok) return;
-      const alerts = (await res.json()) as Array<{
-        itemId: string | null;
-        storeId: string | null;
-        type: string;
-      }>;
+      const alerts = normalizeAlertsPayload(await res.json().catch(() => null));
       setNotifyByItemId((prev) => {
         const next = { ...prev };
         for (const item of results) {
@@ -153,11 +168,7 @@ export default function ItemAvailabilitySearch({
 
     const listRes = await fetch("/api/alerts", { credentials: "include" });
     if (!listRes.ok) return;
-    const alerts = (await listRes.json()) as Array<{
-      id: string;
-      itemId: string | null;
-      type: string;
-    }>;
+    const alerts = normalizeAlertsPayload(await listRes.json().catch(() => null));
     const existing = alerts.find(
       (alert) => alert.type === "item_restock" && alert.itemId === item.id
     );


### PR DESCRIPTION
## Summary
- Fix shopper-facing store page crash in `ItemAvailabilitySearch` caused by assuming alerts API responses are always arrays.
- Add defensive alerts payload normalization so both legacy array responses and `{ alerts: [...] }` responses are handled safely.
- Prevent runtime errors (`alerts.some is not a function`) by defaulting to an empty list when payloads are malformed or unexpected.

## What changed
- Updated `components/ItemAvailabilitySearch.tsx`:
  - Added `normalizeAlertsPayload(payload)` helper.
  - Normalized alerts parsing in:
    - initial alerts fetch inside `useEffect`
    - alerts fetch inside `toggleNotify`
  - Added safe fallback behavior when JSON parse fails or payload shape is invalid.

## Why
- The alerts endpoint returns object-shaped payloads (`{ alerts: [...] }`), while the component previously treated the response as a raw array.
- This mismatch caused `.some()` calls on non-array values and crashed the store page.

## Impact
- Store page remains stable even when alerts responses are malformed or differ in shape.
- Shopper inventory search and alert toggling continue to work without hard failures.

## Test plan
- [x] `npm run lint` (no new errors; only pre-existing warnings in `scripts/signup-machine-tests.ts`)
- [x] Manual: open a store page as shopper and confirm no console crash.
- [x] Manual: verify "Notify me" toggle still works for item restock alerts.
- [x] Manual: verify unauthenticated shopper flow still shows login prompt and does not crash.