### PR TITLE
test: machine-executable unit tests — MyAlertsClient (#75)

### DIFF
--- a/app/(public)/my-alerts/MyAlertsClient.tsx
+++ b/app/(public)/my-alerts/MyAlertsClient.tsx
@@ -23,16 +23,19 @@ type NotificationRow = {
   store: { id: string; name: string };
 };
 
-const KIND_LABELS: Record<string, string> = {
+export const INBOX_KIND_LABELS: Record<string, string> = {
   store_fresh_update: "Fresh update",
   store_new_deal: "New deal",
 };
 
-function kindLabel(kind: string): string {
-  return KIND_LABELS[kind] ?? kind;
+export function inboxKindLabel(kind: string): string {
+  return INBOX_KIND_LABELS[kind] ?? kind;
 }
 
-function byCreatedDesc(a: NotificationRow, b: NotificationRow): number {
+export function notificationsByCreatedDesc(
+  a: NotificationRow,
+  b: NotificationRow,
+): number {
   return new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime();
 }
 
@@ -56,7 +59,7 @@ function InboxNotificationRow({
         <div className="min-w-0">
           <div className="flex items-center gap-2 flex-wrap">
             <span className="text-[11px] font-bold uppercase tracking-wide text-green-800 bg-green-100/80 px-2 py-0.5 rounded-full">
-              {kindLabel(n.kind)}
+              {inboxKindLabel(n.kind)}
             </span>
             {!unread ? (
               <span className="text-[11px] text-gray-400">Read</span>
@@ -237,8 +240,12 @@ export default function MyAlertsClient() {
   }
 
   const { inboxUnread, inboxRead } = useMemo(() => {
-    const unread = notifications.filter((n) => !n.readAt).sort(byCreatedDesc);
-    const read = notifications.filter((n) => n.readAt).sort(byCreatedDesc);
+    const unread = notifications
+      .filter((n) => !n.readAt)
+      .sort(notificationsByCreatedDesc);
+    const read = notifications
+      .filter((n) => n.readAt)
+      .sort(notificationsByCreatedDesc);
     return { inboxUnread: unread, inboxRead: read };
   }, [notifications]);
 

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -1,1 +1,24 @@
 import "@testing-library/jest-dom";
+
+// jsdom has no fetch — provide a default so tests can spyOn(global, "fetch").
+globalThis.fetch =
+  globalThis.fetch ??
+  (jest.fn(() =>
+    Promise.resolve({
+      ok: true,
+      json: async () => ({}),
+    } as Response),
+  ) as unknown as typeof fetch);
+
+class MockEventSource {
+  url: string;
+  constructor(url: string) {
+    this.url = url;
+  }
+  addEventListener() {}
+  removeEventListener() {}
+  close() {}
+}
+
+// StoreFreshUpdatesFeed uses SSE in the browser
+global.EventSource = MockEventSource as unknown as typeof EventSource;

--- a/tests/MyAlertsClient.test.tsx
+++ b/tests/MyAlertsClient.test.tsx
@@ -1,0 +1,156 @@
+import "@testing-library/jest-dom";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import React from "react";
+import MyAlertsClient, {
+  INBOX_KIND_LABELS,
+  inboxKindLabel,
+  notificationsByCreatedDesc,
+} from "@/app/(public)/my-alerts/MyAlertsClient";
+
+describe("inboxKindLabel", () => {
+  it("maps known notification kinds", () => {
+    expect(inboxKindLabel("store_fresh_update")).toBe("Fresh update");
+    expect(inboxKindLabel("store_new_deal")).toBe("New deal");
+  });
+
+  it("falls back to raw kind string", () => {
+    expect(inboxKindLabel("custom_kind")).toBe("custom_kind");
+  });
+});
+
+describe("INBOX_KIND_LABELS", () => {
+  it("includes at least the two primary inbox kinds", () => {
+    expect(INBOX_KIND_LABELS.store_fresh_update).toBeDefined();
+    expect(INBOX_KIND_LABELS.store_new_deal).toBeDefined();
+  });
+});
+
+describe("notificationsByCreatedDesc", () => {
+  it("orders newest first", () => {
+    const a = {
+      id: "1",
+      kind: "k",
+      title: "t",
+      body: null,
+      readAt: null,
+      createdAt: "2026-04-01T00:00:00.000Z",
+      store: { id: "s", name: "S" },
+    };
+    const b = {
+      id: "2",
+      kind: "k",
+      title: "t",
+      body: null,
+      readAt: null,
+      createdAt: "2026-04-02T00:00:00.000Z",
+      store: { id: "s", name: "S" },
+    };
+    expect(notificationsByCreatedDesc(a, b)).toBeGreaterThan(0);
+    expect(notificationsByCreatedDesc(b, a)).toBeLessThan(0);
+  });
+});
+
+describe("MyAlertsClient", () => {
+  beforeEach(() => {
+    jest.spyOn(global, "fetch").mockImplementation(async (input) => {
+      const url = String(input);
+      if (url.includes("/api/alerts")) {
+        return {
+          ok: true,
+          json: async () => ({
+            alerts: [
+              {
+                id: "al1",
+                type: "store_follow",
+                storeId: "s1",
+                itemId: null,
+                createdAt: "2026-04-01T00:00:00.000Z",
+                store: { id: "s1", name: "Mart" },
+                item: null,
+              },
+            ],
+          }),
+        } as Response;
+      }
+      if (url.includes("/api/shopper/notifications")) {
+        return {
+          ok: true,
+          json: async () => ({
+            notifications: [
+              {
+                id: "n1",
+                kind: "store_new_deal",
+                title: "Deal!",
+                body: "10% off",
+                readAt: null,
+                createdAt: "2026-04-05T12:00:00.000Z",
+                store: { id: "s1", name: "Mart" },
+              },
+            ],
+            hasMore: false,
+          }),
+        } as Response;
+      }
+      return { ok: false, json: async () => ({}) } as Response;
+    });
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("renders subscriptions and activity after load", async () => {
+    render(<MyAlertsClient />);
+    await waitFor(() => {
+      expect(screen.getAllByText("Mart").length).toBeGreaterThanOrEqual(1);
+    });
+    expect(screen.getByText(/Deal!/)).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: /Subscriptions/i })).toBeInTheDocument();
+  });
+
+  it("removes an alert optimistically when Turn off succeeds", async () => {
+    const user = userEvent.setup();
+    const fetchMock = global.fetch as jest.Mock;
+    fetchMock.mockImplementation(async (input, init) => {
+      const url = String(input);
+      if (url.includes("/api/alerts/al1") && init?.method === "DELETE") {
+        return { ok: true, json: async () => ({}) } as Response;
+      }
+      if (url.includes("/api/alerts") && !init?.method) {
+        return {
+          ok: true,
+          json: async () => ({
+            alerts: [
+              {
+                id: "al1",
+                type: "store_follow",
+                storeId: "s1",
+                itemId: null,
+                createdAt: "2026-04-01T00:00:00.000Z",
+                store: { id: "s1", name: "Mart" },
+                item: null,
+              },
+            ],
+          }),
+        } as Response;
+      }
+      if (url.includes("/api/shopper/notifications")) {
+        return {
+          ok: true,
+          json: async () => ({ notifications: [], hasMore: false }),
+        } as Response;
+      }
+      return { ok: false, json: async () => ({}) } as Response;
+    });
+
+    render(<MyAlertsClient />);
+    await waitFor(() => screen.getByRole("button", { name: /Turn off/i }));
+    await user.click(screen.getByRole("button", { name: /Turn off/i }));
+    await waitFor(() => {
+      expect(
+        screen.getByText(/No active subscriptions/i),
+      ).toBeInTheDocument();
+    });
+  });
+});

--- a/tests/MyAlertsClient.test.tsx
+++ b/tests/MyAlertsClient.test.tsx
@@ -3,7 +3,6 @@ import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import React from "react";
 import MyAlertsClient, {
-  INBOX_KIND_LABELS,
   inboxKindLabel,
   notificationsByCreatedDesc,
 } from "@/app/(public)/my-alerts/MyAlertsClient";
@@ -16,13 +15,6 @@ describe("inboxKindLabel", () => {
 
   it("falls back to raw kind string", () => {
     expect(inboxKindLabel("custom_kind")).toBe("custom_kind");
-  });
-});
-
-describe("INBOX_KIND_LABELS", () => {
-  it("includes at least the two primary inbox kinds", () => {
-    expect(INBOX_KIND_LABELS.store_fresh_update).toBeDefined();
-    expect(INBOX_KIND_LABELS.store_new_deal).toBeDefined();
   });
 });
 


### PR DESCRIPTION
## Summary

Adds Jest coverage for **Issue #75**: MyAlertsClient.

## Files
- jest.setup.ts- `app/(public)/my-alerts/MyAlertsClient.tsx`\n- `tests/MyAlertsClient.test.tsx`\n\n## Verify\n```bash\nnpm run test:jest\nnpm run lint\n```\n\nFixes #75