### PR TITLE
US4 HAT

### DIFF
--- a/docs/hat/README.md
+++ b/docs/hat/README.md
@@ -5,8 +5,8 @@ Manual QA outcomes and survey responses for user stories. Each file maps to one 
 | User story | Document |
 |------------|----------|
 | US 1 — Fresh Today updates (shopper) | [US1-fresh-today-updates-shopper.md](./US1-fresh-today-updates-shopper.md) |
-| US 4 — Filter stores by specialty | [US4-filter-stores-by-specialty.md](./US4-filter-stores-by-specialty.md) |
 | US 2 — Deals this week (shopper) | [US2-deals-this-week-shopper.md](./US2-deals-this-week-shopper.md) |
+| US 4 — Filter stores by specialty | [US4-filter-stores-by-specialty.md](./US4-filter-stores-by-specialty.md) |
 | US 6 — Secure store owner login | [US6-store-owner-login.md](./US6-store-owner-login.md) |
 
 _Add additional rows and files (e.g. `US7-….md`) as other HATs are run._

--- a/docs/hat/README.md
+++ b/docs/hat/README.md
@@ -5,6 +5,13 @@ Manual QA outcomes and survey responses for user stories. Each file maps to one 
 | User story | Document |
 |------------|----------|
 | US 1 — Fresh Today updates (shopper) | [US1-fresh-today-updates-shopper.md](./US1-fresh-today-updates-shopper.md) |
+| US 4 — Filter stores by specialty | [US4-filter-stores-by-specialty.md](./US4-filter-stores-by-specialty.md) |
 | US 6 — Secure store owner login | [US6-store-owner-login.md](./US6-store-owner-login.md) |
 
 _Add additional rows and files (e.g. `US7-….md`) as other HATs are run._
+
+## Linking the documentation PR to GitHub
+
+When you open a PR that adds or updates HAT markdown here, connect it to the HAT issue (e.g. `Closes #68`, `Fixes #68`, or link under **Development**) so traceability shows on GitHub.
+
+- **US 4** (`US4-filter-stores-by-specialty.md`): **[#68](https://github.com/gsha22/GrocerEase/issues/68)**

--- a/docs/hat/US4-filter-stores-by-specialty.md
+++ b/docs/hat/US4-filter-stores-by-specialty.md
@@ -1,8 +1,12 @@
 # HAT: User Story 4 — Filter stores by specialty
 
 **Related issue:** [#68 — HAT: US 4 — Filter stores by specialty](https://github.com/gsha22/GrocerEase/issues/68)  
-**Implementing change:** [Commit c669730 — Story 4: filter stores by specialty](https://github.com/gsha22/GrocerEase/commit/c669730)  
+**Implementing PR:** [#15 — feat: implement store filtering by specialty category (Story 4)](https://github.com/gsha22/GrocerEase/pull/15)  
 **Tester:** Clarence Choy
+
+## User story
+
+As a shopper, I want to filter stores by specialty category (e.g., Asian groceries, halal, organic, EBT accepted) so that I can find stores relevant to my specific needs.
 
 ## Prerequisites
 
@@ -15,7 +19,7 @@ After following the human acceptance test instructions in issue [#68](https://gi
 
 Traceability note: this document references issue **#68** as the source-of-truth HAT ticket.
 
-## Steps Executed
+## Steps executed
 
 All 7 steps from issue #68 were executed in order:
 
@@ -27,7 +31,9 @@ All 7 steps from issue #68 were executed in order:
 6. **Cleared all** filters and confirmed the **full list** was restored.
 7. Observed **visual treatment** of active filters (highlighting) and whether filters could be **removed individually**.
 
-## Metrics Evaluation
+## Metrics evaluation
+
+Rationale (from test design): (1) **Task success rate** is a binary pass/fail usability metric — if users can't operate the filters correctly, the feature has zero value regardless of design polish. (2) **Response latency perception**: per lecture on engagement metrics, perceived performance directly affects whether users trust and reuse a feature; sub-second is the bar. (3) **Relevance satisfaction** is a precision metric — the Lean Startup build-measure-learn loop requires that what we deliver matches what the user asked for; wrong results are worse than no results.
 
 | # | Metric | Result | Observation |
 |---|--------|--------|-------------|

--- a/docs/hat/US4-filter-stores-by-specialty.md
+++ b/docs/hat/US4-filter-stores-by-specialty.md
@@ -15,13 +15,13 @@ As a shopper, I want to filter stores by specialty category (e.g., Asian groceri
 
 ## Outcome
 
-After following the human acceptance test instructions in issue [#68](https://github.com/gsha22/GrocerEase/issues/68), the tester **successfully completed** the filter workflow on the store directory, including single-filter, combined (**AND**) filters, clearing filters, and confirming the full list restored.
+**Completed.** Clarence Choy followed the human acceptance test instructions in issue [#68](https://github.com/gsha22/GrocerEase/issues/68) and **successfully completed** the filter workflow on the store directory, including single-filter, combined (**AND**) filters, clearing filters, and confirming the full list restored.
 
 Traceability note: this document references issue **#68** as the source-of-truth HAT ticket.
 
 ## Steps executed
 
-All 7 steps from issue #68 were executed in order:
+Protocol from issue #68 (record results after the session):
 
 1. Navigated to the **store directory** page (`/`).
 2. Located the **filter** options (e.g. Asian groceries, halal, organic, produce, EBT accepted).

--- a/docs/hat/US4-filter-stores-by-specialty.md
+++ b/docs/hat/US4-filter-stores-by-specialty.md
@@ -1,0 +1,54 @@
+# HAT: User Story 4 — Filter stores by specialty
+
+**Related issue:** [#68 — HAT: US 4 — Filter stores by specialty](https://github.com/gsha22/GrocerEase/issues/68)  
+**Implementing change:** [Commit c669730 — Story 4: filter stores by specialty](https://github.com/gsha22/GrocerEase/commit/c669730)  
+**Tester:** Clarence Choy
+
+## Prerequisites
+
+- The store directory contains stores tagged with **at least three** different specialty categories.
+- At least one category has **multiple** matching stores; at least one category has **only one** matching store.
+
+## Outcome
+
+After following the human acceptance test instructions in issue [#68](https://github.com/gsha22/GrocerEase/issues/68), the tester **successfully completed** the filter workflow on the store directory, including single-filter, combined (**AND**) filters, clearing filters, and confirming the full list restored.
+
+Traceability note: this document references issue **#68** as the source-of-truth HAT ticket.
+
+## Steps Executed
+
+All 7 steps from issue #68 were executed in order:
+
+1. Navigated to the **store directory** page (`/`).
+2. Located the **filter** options (e.g. Asian groceries, halal, organic, produce, EBT accepted).
+3. Selected **one** filter and observed how the list updated (including whether it updated **without a full page reload**).
+4. Selected a **second** filter simultaneously and confirmed the results **narrowed** (**AND** logic).
+5. **Cleared one** filter and confirmed the results **broadened** accordingly.
+6. **Cleared all** filters and confirmed the **full list** was restored.
+7. Observed **visual treatment** of active filters (highlighting) and whether filters could be **removed individually**.
+
+## Metrics Evaluation
+
+| # | Metric | Result | Observation |
+|---|--------|--------|-------------|
+| 1 | **Task success rate** (apply, combine, and clear filters without errors) | ✅ Pass | Tester completed the filter journey without confusion; category use case in the survey was straightforward (see Q1). |
+| 2 | **Response latency perception** (instant vs. noticeable wait) | ✅ Pass | Filtering felt **fast enough** that the tester did not perceive an annoying wait (see Q2). |
+| 3 | **Relevance satisfaction** (results match expectations for selected categories) | ✅ Pass | Category **labels were clear**; tester could map a dietary need to an appropriate filter choice (see Q3). |
+
+## Survey
+
+### Q1. Imagine you just moved to a new neighborhood and keep kosher (or have another dietary requirement). Walk me through how you'd use this page to find a store. Was anything confusing?
+
+**Answer:** I would go to the store page and find the Kosher filter to filter stores that sell Kosher ingredients.
+
+### Q2. When you tapped a filter, did the results update fast enough that you didn't notice a wait?
+
+**Answer:** Yes it was fast enough
+
+### Q3. Were the category labels clear to you, or were there any that you weren't sure what they meant?
+
+**Answer:** Yes they were clear
+
+## Iteration
+
+No issues were encountered during the test session. No iteration was required.


### PR DESCRIPTION
closes #68 
US4 HAT doc was missing structural elements present in every other HAT report (US1, US2, US6) and had a stale commit link instead of the implementing PR reference.

## Changes to `docs/hat/US4-filter-stores-by-specialty.md`

- **User story** — added the story statement section (was the only HAT doc without one)
- **Implementing PR** — replaced raw commit `c669730` with `[#15 — feat: implement store filtering by specialty category](https://github.com/gsha22/GrocerEase/pull/15)`
- **Metrics rationale** — added the "Why This Metric" rationale paragraph above the results table, sourced from issue #68, matching the format used in US1/US2
- **Section header casing** — "Steps Executed" → "Steps executed", "Metrics Evaluation" → "Metrics evaluation" (sentence case, consistent with all other HAT docs)