### PR TITLE
fix(search): link FreshUpdates to Items on post, filter stale/deleted from search

### DIFF
--- a/app/api/stores/[id]/items/route.ts
+++ b/app/api/stores/[id]/items/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
+import { FRESH_UPDATE_PUBLIC_WINDOW_MS } from "@/lib/fresh-updates";
 
 const MAX_RESULTS = 50;
 const MAX_CANDIDATES = 250;
@@ -55,6 +56,17 @@ export async function GET(
       return NextResponse.json([]);
     }
 
+    const windowStart = new Date(Date.now() - FRESH_UPDATE_PUBLIC_WINDOW_MS);
+    const hasActiveFreshUpdate = {
+      some: { deletedAt: null, createdAt: { gte: windowStart } },
+    };
+    const freshUpdateSelect = {
+      where: { deletedAt: null, createdAt: { gte: windowStart } },
+      orderBy: { createdAt: "desc" as const },
+      take: 1,
+      select: { createdAt: true },
+    };
+
     const [store, directMatches, broadMatches] = await Promise.all([
       prisma.store.findUnique({
         where: { id: storeId },
@@ -63,6 +75,7 @@ export async function GET(
       prisma.item.findMany({
         where: {
           storeId,
+          freshUpdates: hasActiveFreshUpdate,
           OR: [
             { name: { contains: q, mode: "insensitive" } },
             { name: { contains: query, mode: "insensitive" } },
@@ -73,17 +86,19 @@ export async function GET(
           name: true,
           inStock: true,
           lastUpdated: true,
+          freshUpdates: freshUpdateSelect,
           store: { select: { id: true, name: true, address: true } },
         },
         take: MAX_CANDIDATES,
       }),
       prisma.item.findMany({
-        where: { storeId },
+        where: { storeId, freshUpdates: hasActiveFreshUpdate },
         select: {
           id: true,
           name: true,
           inStock: true,
           lastUpdated: true,
+          freshUpdates: freshUpdateSelect,
           store: { select: { id: true, name: true, address: true } },
         },
         take: MAX_CANDIDATES,
@@ -139,7 +154,7 @@ export async function GET(
         store_id: item.store.id,
         store_name: item.store.name,
         store_location: item.store.address,
-        last_updated: item.lastUpdated.toISOString(),
+        last_updated: (item.freshUpdates[0]?.createdAt ?? item.lastUpdated).toISOString(),
       }));
 
     return NextResponse.json(scored);

--- a/app/api/stores/[id]/updates/route.ts
+++ b/app/api/stores/[id]/updates/route.ts
@@ -68,9 +68,32 @@ export async function POST(
     return NextResponse.json({ error: parsed.error }, { status: 400 });
   }
 
+  const existingItem = await prisma.item.findFirst({
+    where: {
+      storeId,
+      name: { equals: parsed.itemName, mode: "insensitive" },
+    },
+    select: { id: true },
+  });
+
+  let itemId: string;
+  if (existingItem) {
+    await prisma.item.update({
+      where: { id: existingItem.id },
+      data: { name: parsed.itemName },
+    });
+    itemId = existingItem.id;
+  } else {
+    const newItem = await prisma.item.create({
+      data: { storeId, name: parsed.itemName },
+    });
+    itemId = newItem.id;
+  }
+
   const update = await prisma.freshUpdate.create({
     data: {
       storeId,
+      itemId,
       itemName: parsed.itemName,
       note: parsed.note,
     },


### PR DESCRIPTION
Closes #102

## Summary
- **POST `/api/stores/:id/updates`** now upserts an `Item` record before creating the `FreshUpdate`, and links them via `itemId` — fixes newly posted items not appearing in search
- **GET `/api/stores/:id/items`** now filters to items that have at least one active `FreshUpdate` (`deletedAt: null`, `createdAt` within the 7-day public window) — fixes stale/soft-deleted items appearing in search results
- `last_updated` in search results now reflects the most recent active `FreshUpdate`'s `createdAt` so shoppers see when the owner actually posted the update, not when the DB record was last touched

## Test plan
- [x] `npx jest` — 152/152 pass (all suites)
- [ ] Post a new item via the store dashboard → search for it immediately as a shopper → it should appear
- [ ] Confirm items whose only FreshUpdates are soft-deleted or older than 7 days do not appear in search
- [ ] Confirm the "updated X ago" timestamp in search results matches the FreshUpdate post time, not the item record timestamp

🤖 Generated with [Claude Code](https://claude.com/claude-code)