### PR TITLE
fix: wrong links in implementing PRs in HAT docs

### DIFF
--- a/docs/hat/US11-fresh-today-updates-owner.md
+++ b/docs/hat/US11-fresh-today-updates-owner.md
@@ -1,7 +1,7 @@
 # HAT: User Story 11 — Fresh Today updates (owner)
 
 **Related issue:** [#65 — HAT: Discover nearby stores (shopper)](https://github.com/gsha22/GrocerEase/issues/65)  
-**Implementing PR:** https://github.com/gsha22/GrocerEase/pull/106
+**Implementing PR:** [#35 — feat: add fresh updates functionality and enhance store profile page ](https://github.com/gsha22/GrocerEase/pull/35)
 **Tester:** Christine Tran
 
 ## User story

--- a/docs/hat/US12-subscribe-store-or-item-shopper.md
+++ b/docs/hat/US12-subscribe-store-or-item-shopper.md
@@ -1,7 +1,7 @@
 # HAT: User Story 12 — Subscribe to a store or item (shopper)
 
 **Related issue:** [#64 — HAT: Subscribe to a store or item (shopper)](https://github.com/gsha22/GrocerEase/issues/64)  
-**Implementing PR:** https://github.com/gsha22/GrocerEase/pull/108
+**Implementing PR:** [#42 — Feature/shopper activity inbox](https://github.com/gsha22/GrocerEase/pull/43)
 **Tester:** Scarlett Huang
 
 ## User story

--- a/docs/hat/US2-deals-this-week-shopper.md
+++ b/docs/hat/US2-deals-this-week-shopper.md
@@ -1,7 +1,7 @@
 # HAT: User Story 2 — Deals this week (shopper)
 
 **Related issue:** [#63 — HAT: Deals this week (shopper)](https://github.com/gsha22/GrocerEase/issues/63)  
-**Implementing PR:** [#110 — US 2 HAT](https://github.com/gsha22/GrocerEase/pull/110)  
+**Implementing PR:** [#19 — feat: implement deals this week for shoppers (Story 2)](https://github.com/gsha22/GrocerEase/pull/19)  
 **Tester:** Scarlett Huang
 
 ## User story

--- a/docs/hat/US3-discover-nearby-stores-shopper.md
+++ b/docs/hat/US3-discover-nearby-stores-shopper.md
@@ -1,7 +1,7 @@
 # HAT: User Story 3 — Discover nearby stores (shopper)
 
 **Related issue:** [#66 — HAT: Discover nearby stores (shopper)](https://github.com/gsha22/GrocerEase/issues/66)  
-**Implementing PR:** _Add PR link here when tracked in #66._  
+**Implementing PR:** [#14 — feat: implement Story 3 (Discover Nearby Stores)](https://github.com/gsha22/GrocerEase/pull/14)  
 **Tester:** Christine Tran
 
 ## User story


### PR DESCRIPTION
Links for implementing PRs were wrong for HAT 2, 3, 11, and 12. 