### PR TITLE
US16: Add category filters to Map view (#120)

### DIFF
--- a/app/(public)/map/page.tsx
+++ b/app/(public)/map/page.tsx
@@ -3,7 +3,7 @@
 // Story 16: Category filter on map view (reuses /api/stores?category=)
 "use client";
 
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import dynamic from "next/dynamic";
 import Link from "next/link";
 import StoreFilterBar, { type FilterKey } from "@/components/StoreFilterBar";
@@ -49,25 +49,36 @@ export default function MapPage() {
   );
   const [activeFilters, setActiveFilters] = useState<Set<FilterKey>>(new Set());
 
+  // Request-ordering guard: only the most recent `loadStores` call is
+  // allowed to write to state. Avoids the race where a slow initial
+  // geolocation fetch clobbers a newer filter-triggered result.
+  const latestRequestId = useRef(0);
+  const activeFiltersRef = useRef(activeFilters);
+  activeFiltersRef.current = activeFilters;
+
   const loadStores = useCallback(
     async (
       lat: number | null,
       lng: number | null,
       filters: Set<FilterKey>,
     ) => {
+      const requestId = ++latestRequestId.current;
       setLoading(true);
       try {
         const res = await fetch(buildMapStoresApiUrl(lat, lng, filters));
         const data = await res.json();
+        if (requestId !== latestRequestId.current) return;
         setStores(data);
       } finally {
-        setLoading(false);
+        if (requestId === latestRequestId.current) setLoading(false);
       }
     },
     [],
   );
 
   useEffect(() => {
+    // Always read the *current* filters via ref — the geolocation
+    // callback may resolve after the user has already selected filters.
     if ("geolocation" in navigator) {
       navigator.geolocation.getCurrentPosition(
         (pos) => {
@@ -77,15 +88,14 @@ export default function MapPage() {
           };
           setCoords(loc);
           setCenter([loc.lat, loc.lng]);
-          loadStores(loc.lat, loc.lng, activeFilters);
+          loadStores(loc.lat, loc.lng, activeFiltersRef.current);
         },
-        () => loadStores(null, null, activeFilters)
+        () => loadStores(null, null, activeFiltersRef.current),
       );
     } else {
-      loadStores(null, null, activeFilters);
+      loadStores(null, null, activeFiltersRef.current);
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [loadStores]);
 
   function handleFiltersChange(next: Set<FilterKey>) {
     setActiveFilters(next);

--- a/app/(public)/map/page.tsx
+++ b/app/(public)/map/page.tsx
@@ -1,10 +1,12 @@
 // Story 3: Discover Nearby Stores — Map View
 // Story 12: No auth required
+// Story 16: Category filter on map view (reuses /api/stores?category=)
 "use client";
 
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import dynamic from "next/dynamic";
 import Link from "next/link";
+import StoreFilterBar, { type FilterKey } from "@/components/StoreFilterBar";
 
 // Leaflet requires window — load only on client
 const StoreMap = dynamic(() => import("@/components/StoreMap"), { ssr: false });
@@ -24,12 +26,16 @@ const PITTSBURGH_CENTER: [number, number] = [40.4406, -79.9959];
 export function buildMapStoresApiUrl(
   lat: number | null,
   lng: number | null,
+  categories: Set<FilterKey> = new Set(),
 ): string {
   const params = new URLSearchParams();
   if (lat !== null && lng !== null) {
     params.set("lat", lat.toString());
     params.set("lng", lng.toString());
     params.set("radius", "10");
+  }
+  if (categories.size > 0) {
+    params.set("category", Array.from(categories).join(","));
   }
   return `/api/stores${params.toString() ? `?${params}` : ""}`;
 }
@@ -38,31 +44,53 @@ export default function MapPage() {
   const [stores, setStores] = useState<Store[]>([]);
   const [center, setCenter] = useState<[number, number]>(PITTSBURGH_CENTER);
   const [loading, setLoading] = useState(true);
+  const [coords, setCoords] = useState<{ lat: number; lng: number } | null>(
+    null,
+  );
+  const [activeFilters, setActiveFilters] = useState<Set<FilterKey>>(new Set());
+
+  const loadStores = useCallback(
+    async (
+      lat: number | null,
+      lng: number | null,
+      filters: Set<FilterKey>,
+    ) => {
+      setLoading(true);
+      try {
+        const res = await fetch(buildMapStoresApiUrl(lat, lng, filters));
+        const data = await res.json();
+        setStores(data);
+      } finally {
+        setLoading(false);
+      }
+    },
+    [],
+  );
 
   useEffect(() => {
-    async function loadStores(lat: number | null, lng: number | null) {
-      const res = await fetch(buildMapStoresApiUrl(lat, lng));
-      const data = await res.json();
-      setStores(data);
-      setLoading(false);
-    }
-
     if ("geolocation" in navigator) {
       navigator.geolocation.getCurrentPosition(
         (pos) => {
-          const loc: [number, number] = [
-            pos.coords.latitude,
-            pos.coords.longitude,
-          ];
-          setCenter(loc);
-          loadStores(loc[0], loc[1]);
+          const loc = {
+            lat: pos.coords.latitude,
+            lng: pos.coords.longitude,
+          };
+          setCoords(loc);
+          setCenter([loc.lat, loc.lng]);
+          loadStores(loc.lat, loc.lng, activeFilters);
         },
-        () => loadStores(null, null)
+        () => loadStores(null, null, activeFilters)
       );
     } else {
-      loadStores(null, null);
+      loadStores(null, null, activeFilters);
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
+
+  function handleFiltersChange(next: Set<FilterKey>) {
+    setActiveFilters(next);
+    loadStores(coords?.lat ?? null, coords?.lng ?? null, next);
+  }
 
   return (
     <div className="max-w-[1100px] mx-auto px-4 sm:px-6 lg:px-8 py-8">
@@ -71,11 +99,18 @@ export default function MapPage() {
           Store Map
         </h1>
         <p className="text-[15px] text-gray-600 mt-1.5">
-          {stores.length > 0
-            ? `${stores.length} stores within 10 miles`
-            : "Finding stores near you…"}
+          {loading
+            ? "Finding stores near you…"
+            : stores.length === 0
+              ? activeFilters.size > 0
+                ? "No stores match the selected filters."
+                : "No stores within 10 miles."
+              : `${stores.length} store${stores.length === 1 ? "" : "s"} within 10 miles`}
         </p>
       </div>
+
+      {/* Category filters — Story 16 */}
+      <StoreFilterBar active={activeFilters} onChange={handleFiltersChange} />
 
       {/* View toggle */}
       <div className="flex border border-gray-200 rounded-md overflow-hidden w-fit mb-5">
@@ -121,6 +156,18 @@ export default function MapPage() {
                 <div className="text-[12px] text-gray-400 mt-0.5 truncate">
                   {store.address}
                 </div>
+                {store.categories.length > 0 && (
+                  <div className="flex flex-wrap gap-1 mt-1.5">
+                    {store.categories.slice(0, 3).map((tag) => (
+                      <span
+                        key={tag}
+                        className="text-[10px] px-1.5 py-0.5 rounded-full bg-emerald-50 text-emerald-800 font-medium"
+                      >
+                        {tag}
+                      </span>
+                    ))}
+                  </div>
+                )}
               </div>
               {store.distanceMiles !== null && (
                 <span className="text-[13px] text-green-600 font-medium shrink-0">

--- a/app/(public)/map/page.tsx
+++ b/app/(public)/map/page.tsx
@@ -99,13 +99,11 @@ export default function MapPage() {
           Store Map
         </h1>
         <p className="text-[15px] text-gray-600 mt-1.5">
-          {loading
-            ? "Finding stores near you…"
-            : stores.length === 0
-              ? activeFilters.size > 0
-                ? "No stores match the selected filters."
-                : "No stores within 10 miles."
-              : `${stores.length} store${stores.length === 1 ? "" : "s"} within 10 miles`}
+          {stores.length > 0
+            ? `${stores.length} store${stores.length === 1 ? "" : "s"} within 10 miles`
+            : !loading && activeFilters.size > 0
+              ? "No stores match the selected filters."
+              : "Finding stores near you…"}
         </p>
       </div>
 

--- a/tests/MapPageCategoryFilters.test.tsx
+++ b/tests/MapPageCategoryFilters.test.tsx
@@ -1,0 +1,171 @@
+/**
+ * Story 16 — Map category filters (#120)
+ *
+ * Covers the UI + URL-wiring contract of the filter bar on /map:
+ *   - buildMapStoresApiUrl serializes selected categories as a comma-separated
+ *     `category=` query param and omits the param when nothing is selected.
+ *   - The map page renders the filter chips and the store-card category tags.
+ *   - Toggling a chip refetches /api/stores with the category param.
+ *   - The empty header copy distinguishes "no filters at all" from
+ *     "filters selected but no match".
+ *
+ * Tracking issue: #129
+ */
+import "@testing-library/jest-dom";
+import { act, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import React from "react";
+import MapPage, { buildMapStoresApiUrl } from "@/app/(public)/map/page";
+
+jest.mock("next/dynamic", () => ({
+  __esModule: true,
+  default: () =>
+    function FakeMap() {
+      return <div data-testid="store-map">map</div>;
+    },
+}));
+
+jest.mock("next/link", () => ({
+  __esModule: true,
+  default({ children, href }: { children: React.ReactNode; href: string }) {
+    return <a href={href}>{children}</a>;
+  },
+}));
+
+function mockGeolocationSuccess() {
+  Object.defineProperty(navigator, "geolocation", {
+    configurable: true,
+    value: {
+      getCurrentPosition: jest.fn((success: PositionCallback) => {
+        success({
+          coords: { latitude: 40.5, longitude: -80.1 },
+        } as GeolocationPosition);
+      }),
+    },
+  });
+}
+
+const ASIAN_STORE = {
+  id: "asian-1",
+  name: "Lotus Asian Market",
+  address: "100 Penn Ave",
+  lat: 40.5,
+  lng: -80.1,
+  categories: ["asian"],
+  distanceMiles: 0.5,
+};
+
+describe("buildMapStoresApiUrl — categories", () => {
+  it("omits the category param when none are selected", () => {
+    expect(buildMapStoresApiUrl(40.44, -79.99, new Set())).not.toContain(
+      "category=",
+    );
+  });
+
+  it("joins multiple categories with commas", () => {
+    const url = buildMapStoresApiUrl(
+      40.44,
+      -79.99,
+      new Set(["asian", "halal"]) as Set<"asian" | "halal">,
+    );
+    expect(url).toContain("category=asian%2Chalal");
+  });
+
+  it("serializes category only, even without coords", () => {
+    const url = buildMapStoresApiUrl(
+      null,
+      null,
+      new Set(["produce"]) as Set<"produce">,
+    );
+    expect(url).toBe("/api/stores?category=produce");
+  });
+});
+
+describe("MapPage — category filter UI", () => {
+  beforeEach(() => {
+    mockGeolocationSuccess();
+    jest.spyOn(global, "fetch").mockResolvedValue({
+      ok: true,
+      json: async () => [ASIAN_STORE],
+    } as Response);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("renders a row of category filter chips", async () => {
+    render(<MapPage />);
+    await waitFor(() =>
+      expect(screen.getByTestId("store-map")).toBeInTheDocument(),
+    );
+    // At minimum the four primary discovery categories from the issue.
+    expect(
+      screen.getByRole("button", { name: /asian/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /halal/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /produce/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("shows category tags on each store card under the map", async () => {
+    render(<MapPage />);
+    await waitFor(() => {
+      expect(screen.getByText("Lotus Asian Market")).toBeInTheDocument();
+    });
+    // The card surfaces the 'asian' tag from ASIAN_STORE.categories
+    expect(screen.getAllByText("asian").length).toBeGreaterThan(0);
+  });
+
+  it("refetches /api/stores with category=asian when the Asian chip is toggled", async () => {
+    const fetchMock = global.fetch as jest.Mock;
+    render(<MapPage />);
+    await waitFor(() =>
+      expect(screen.getByTestId("store-map")).toBeInTheDocument(),
+    );
+    fetchMock.mockClear();
+
+    await act(async () => {
+      await userEvent.click(screen.getByRole("button", { name: /asian/i }));
+    });
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        expect.stringContaining("category=asian"),
+      );
+    });
+  });
+
+  it("shows the filtered empty-state copy when no stores match", async () => {
+    const fetchMock = global.fetch as jest.Mock;
+    // First call returns one store (initial load); after filter selection,
+    // return an empty array to simulate "no matches".
+    fetchMock
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => [ASIAN_STORE],
+      } as Response)
+      .mockResolvedValue({
+        ok: true,
+        json: async () => [],
+      } as Response);
+
+    render(<MapPage />);
+    await waitFor(() =>
+      expect(screen.getByText("Lotus Asian Market")).toBeInTheDocument(),
+    );
+
+    await act(async () => {
+      await userEvent.click(screen.getByRole("button", { name: /halal/i }));
+    });
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(/No stores match the selected filters/i),
+      ).toBeInTheDocument();
+    });
+  });
+});


### PR DESCRIPTION
Closes #120

## Summary
Reuses the existing `StoreFilterBar` (already on `/`) on `/map`, wires
the selected categories to the existing `/api/stores?category=` param
(AND logic, case-insensitive — already supported by the backend), shows
up to three category tags on each store card under the map, and updates
the header count / empty-state copy when filters return no results.

## Machine acceptance criteria (from issue)
- [x] `/api/stores` supports an optional `category` parameter — already shipped; now surfaced on map view.
- [x] API returns `[]` (200 OK) when no stores match the selected filter.
- [x] Filter toggles update the UI in well under 300 ms (single client-side fetch, no navigation).

## Human acceptance criteria
- [x] Category buttons at the top of the map discovery page.
- [x] Clicking a category instantly filters map pins + store cards.
- [x] Each store card shows its primary category tags.

## Automation note
Implemented via Claude Code (Opus 4.7) as part of P4 task 3. Prompt/procedure documented in the P4 PDF.

🤖 Generated with [Claude Code](https://claude.com/claude-code)