### PR TITLE
US17: Shopper reports for incorrect store info (#121)

### DIFF
--- a/app/(dashboard)/dashboard/reports/page.tsx
+++ b/app/(dashboard)/dashboard/reports/page.tsx
@@ -1,0 +1,116 @@
+// Story 17: Owner view of shopper-submitted reports for their own store.
+import Link from "next/link";
+import { auth } from "@/auth";
+import { prisma } from "@/lib/prisma";
+
+export const dynamic = "force-dynamic";
+
+const TYPE_LABELS: Record<string, string> = {
+  out_of_stock: "Out of stock",
+  incorrect_hours: "Hours wrong",
+  wrong_price: "Price wrong",
+  other: "Other",
+};
+
+function formatReportTime(d: Date) {
+  return new Intl.DateTimeFormat("en-US", {
+    month: "short",
+    day: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+  }).format(d);
+}
+
+export default async function DashboardReportsPage() {
+  const session = await auth();
+  const ownerId = session?.user?.id;
+
+  const store = ownerId
+    ? await prisma.store.findUnique({
+        where: { ownerId },
+        select: { id: true, name: true },
+      })
+    : null;
+
+  if (!store) {
+    return (
+      <div className="mx-auto max-w-3xl px-4 py-10">
+        <h1 className="font-display text-2xl font-semibold text-gray-800">
+          Reports
+        </h1>
+        <p className="mt-4 text-[14px] text-gray-500">
+          Create a store profile first to start receiving shopper reports.
+        </p>
+        <Link
+          href="/dashboard/profile"
+          className="mt-4 inline-block text-emerald-800 font-medium hover:underline"
+        >
+          Go to store profile →
+        </Link>
+      </div>
+    );
+  }
+
+  const reports = await prisma.storeReport.findMany({
+    where: { storeId: store.id },
+    orderBy: { createdAt: "desc" },
+    select: {
+      id: true,
+      type: true,
+      comment: true,
+      createdAt: true,
+    },
+    take: 100,
+  });
+
+  return (
+    <div className="mx-auto max-w-3xl px-4 py-10">
+      <div className="mb-6">
+        <h1 className="font-display text-2xl font-semibold text-gray-800">
+          Reports
+        </h1>
+        <p className="mt-1 text-[14px] text-gray-500">
+          Shoppers have flagged these about <strong>{store.name}</strong>. Use
+          them as hints — they are anonymous.
+        </p>
+      </div>
+
+      {reports.length === 0 ? (
+        <div className="rounded-2xl border border-dashed border-gray-200 bg-white px-6 py-12 text-center">
+          <p className="text-[15px] font-medium text-gray-700">No reports yet</p>
+          <p className="mt-2 text-[13px] text-gray-500">
+            When a shopper reports incorrect info for your store, it will appear
+            here.
+          </p>
+        </div>
+      ) : (
+        <ul className="space-y-2">
+          {reports.map((r) => (
+            <li
+              key={r.id}
+              className="rounded-xl border border-gray-200 bg-white p-4"
+            >
+              <div className="flex items-start justify-between gap-3">
+                <span className="inline-flex items-center rounded-full bg-emerald-50 px-2.5 py-0.5 text-[12px] font-semibold text-emerald-900">
+                  {TYPE_LABELS[r.type] ?? r.type}
+                </span>
+                <span className="text-[12px] text-gray-400 shrink-0">
+                  {formatReportTime(r.createdAt)}
+                </span>
+              </div>
+              {r.comment ? (
+                <p className="mt-2 text-[14px] text-gray-700 leading-relaxed">
+                  {r.comment}
+                </p>
+              ) : (
+                <p className="mt-2 text-[13px] text-gray-400 italic">
+                  No additional comment.
+                </p>
+              )}
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/app/(dashboard)/dashboard/reports/page.tsx
+++ b/app/(dashboard)/dashboard/reports/page.tsx
@@ -1,5 +1,6 @@
 // Story 17: Owner view of shopper-submitted reports for their own store.
 import Link from "next/link";
+import { redirect } from "next/navigation";
 import { auth } from "@/auth";
 import { prisma } from "@/lib/prisma";
 
@@ -23,14 +24,15 @@ function formatReportTime(d: Date) {
 
 export default async function DashboardReportsPage() {
   const session = await auth();
-  const ownerId = session?.user?.id;
+  if (!session?.user?.id || session.role !== "owner") {
+    redirect("/login");
+  }
+  const ownerId = session.user.id;
 
-  const store = ownerId
-    ? await prisma.store.findUnique({
-        where: { ownerId },
-        select: { id: true, name: true },
-      })
-    : null;
+  const store = await prisma.store.findUnique({
+    where: { ownerId },
+    select: { id: true, name: true },
+  });
 
   if (!store) {
     return (

--- a/app/(public)/stores/[id]/page.tsx
+++ b/app/(public)/stores/[id]/page.tsx
@@ -18,6 +18,7 @@ import Link from "next/link";
 import ItemAvailabilitySearch from "@/components/ItemAvailabilitySearch";
 import StoreAlertSubscribe from "@/components/StoreAlertSubscribe";
 import StoreFreshUpdatesFeed from "@/components/StoreFreshUpdatesFeed";
+import StoreReportButton from "@/components/StoreReportButton";
 
 export const dynamic = "force-dynamic";
 
@@ -204,6 +205,11 @@ export default async function StoreProfilePage({
           storeId={store.id}
           initialUpdates={initialFreshUpdates}
         />
+      </div>
+
+      {/* Report incorrect info — Story 17 */}
+      <div className="mt-6 mb-4">
+        <StoreReportButton storeId={store.id} viewerRole={viewerRole} />
       </div>
 
       {/* Deals This Week — Story 2 */}

--- a/app/api/stores/[id]/report/route.ts
+++ b/app/api/stores/[id]/report/route.ts
@@ -1,0 +1,92 @@
+// Story 17: Shopper reports of incorrect or outdated store information.
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { requireShopperSession } from "@/lib/require-shopper-session";
+
+const REPORT_TYPES = [
+  "out_of_stock",
+  "incorrect_hours",
+  "wrong_price",
+  "other",
+] as const;
+type ReportType = (typeof REPORT_TYPES)[number];
+
+const COMMENT_MAX = 280;
+const DUPLICATE_WINDOW_MS = 24 * 60 * 60 * 1000;
+
+export async function POST(
+  req: NextRequest,
+  ctx: { params: Promise<{ id: string }> },
+) {
+  const gate = await requireShopperSession();
+  if (!gate.ok) return gate.response;
+  const { session } = gate;
+  const { id: storeId } = await ctx.params;
+
+  const body = await req.json().catch(() => null);
+  const type = body?.type;
+  const commentRaw = body?.comment;
+
+  if (!type || !REPORT_TYPES.includes(type)) {
+    return NextResponse.json(
+      { error: "Invalid report type", allowed: REPORT_TYPES },
+      { status: 400 },
+    );
+  }
+  let comment: string | null = null;
+  if (commentRaw != null) {
+    if (typeof commentRaw !== "string") {
+      return NextResponse.json(
+        { error: "comment must be a string" },
+        { status: 400 },
+      );
+    }
+    const trimmed = commentRaw.trim();
+    if (trimmed.length > COMMENT_MAX) {
+      return NextResponse.json(
+        { error: `comment too long (max ${COMMENT_MAX} characters)` },
+        { status: 400 },
+      );
+    }
+    comment = trimmed || null;
+  }
+
+  const store = await prisma.store.findUnique({
+    where: { id: storeId },
+    select: { id: true },
+  });
+  if (!store) {
+    return NextResponse.json({ error: "Store not found" }, { status: 404 });
+  }
+
+  const since = new Date(Date.now() - DUPLICATE_WINDOW_MS);
+  const recent = await prisma.storeReport.findFirst({
+    where: {
+      storeId,
+      shopperId: session.user.id,
+      createdAt: { gt: since },
+    },
+    select: { id: true },
+  });
+  if (recent) {
+    return NextResponse.json(
+      {
+        error:
+          "You've already reported this store in the last 24 hours. Thanks for helping keep info fresh.",
+      },
+      { status: 429 },
+    );
+  }
+
+  const report = await prisma.storeReport.create({
+    data: {
+      storeId,
+      shopperId: session.user.id,
+      type: type as ReportType,
+      comment,
+    },
+    select: { id: true, type: true, comment: true, createdAt: true },
+  });
+
+  return NextResponse.json({ report }, { status: 201 });
+}

--- a/app/api/stores/[id]/report/route.ts
+++ b/app/api/stores/[id]/report/route.ts
@@ -60,33 +60,61 @@ export async function POST(
   }
 
   const since = new Date(Date.now() - DUPLICATE_WINDOW_MS);
-  const recent = await prisma.storeReport.findFirst({
-    where: {
-      storeId,
-      shopperId: session.user.id,
-      createdAt: { gt: since },
-    },
-    select: { id: true },
-  });
-  if (recent) {
-    return NextResponse.json(
-      {
-        error:
-          "You've already reported this store in the last 24 hours. Thanks for helping keep info fresh.",
+  // Atomic check-then-create: Serializable isolation ensures two concurrent
+  // POSTs can't both pass the "no recent duplicate" check and then both
+  // insert. The loser aborts with a serialization failure (P2034), which we
+  // translate to the same 429 the UI already handles.
+  try {
+    const report = await prisma.$transaction(
+      async (tx) => {
+        const recent = await tx.storeReport.findFirst({
+          where: {
+            storeId,
+            shopperId: session.user.id,
+            createdAt: { gt: since },
+          },
+          select: { id: true },
+        });
+        if (recent) return null;
+        return tx.storeReport.create({
+          data: {
+            storeId,
+            shopperId: session.user.id,
+            type: type as ReportType,
+            comment,
+          },
+          select: { id: true, type: true, comment: true, createdAt: true },
+        });
       },
-      { status: 429 },
+      { isolationLevel: "Serializable" },
     );
+
+    if (!report) {
+      return NextResponse.json(
+        {
+          error:
+            "You've already reported this store in the last 24 hours. Thanks for helping keep info fresh.",
+        },
+        { status: 429 },
+      );
+    }
+
+    return NextResponse.json({ report }, { status: 201 });
+  } catch (e) {
+    if (
+      typeof e === "object" &&
+      e !== null &&
+      "code" in e &&
+      (e as { code?: string }).code === "P2034"
+    ) {
+      return NextResponse.json(
+        {
+          error:
+            "You've already reported this store in the last 24 hours. Thanks for helping keep info fresh.",
+        },
+        { status: 429 },
+      );
+    }
+    throw e;
   }
-
-  const report = await prisma.storeReport.create({
-    data: {
-      storeId,
-      shopperId: session.user.id,
-      type: type as ReportType,
-      comment,
-    },
-    select: { id: true, type: true, comment: true, createdAt: true },
-  });
-
-  return NextResponse.json({ report }, { status: 201 });
 }

--- a/app/api/stores/[id]/reports/route.ts
+++ b/app/api/stores/[id]/reports/route.ts
@@ -1,0 +1,39 @@
+// Story 17: Owner-scoped listing of reports for their own store.
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { requireOwnerSession } from "@/lib/require-owner-session";
+
+export async function GET(
+  _req: NextRequest,
+  ctx: { params: Promise<{ id: string }> },
+) {
+  const gate = await requireOwnerSession();
+  if (!gate.ok) return gate.response;
+  const { session } = gate;
+  const { id: storeId } = await ctx.params;
+
+  const store = await prisma.store.findUnique({
+    where: { id: storeId },
+    select: { id: true, ownerId: true },
+  });
+  if (!store) {
+    return NextResponse.json({ error: "Store not found" }, { status: 404 });
+  }
+  if (store.ownerId !== session.user.id) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  const reports = await prisma.storeReport.findMany({
+    where: { storeId },
+    orderBy: { createdAt: "desc" },
+    select: {
+      id: true,
+      type: true,
+      comment: true,
+      createdAt: true,
+    },
+    take: 100,
+  });
+
+  return NextResponse.json({ reports });
+}

--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -11,6 +11,7 @@ const sections = [
       { href: "/dashboard/profile", label: "Store Profile", icon: "🏪" },
       { href: "/dashboard/posts", label: "Fresh Updates", icon: "📝" },
       { href: "/dashboard/deals", label: "Deals", icon: "🏷" },
+      { href: "/dashboard/reports", label: "Reports", icon: "🚩" },
     ],
   },
 ];

--- a/components/StoreReportButton.tsx
+++ b/components/StoreReportButton.tsx
@@ -1,0 +1,175 @@
+// Story 17: Shopper-facing "report incorrect info" button + lightweight form.
+"use client";
+
+import Link from "next/link";
+import { useState } from "react";
+import type { ViewerRole } from "@/lib/viewer-role";
+
+type ReportType =
+  | "out_of_stock"
+  | "incorrect_hours"
+  | "wrong_price"
+  | "other";
+
+const TYPE_OPTIONS: { value: ReportType; label: string; hint: string }[] = [
+  { value: "out_of_stock", label: "Out of stock", hint: "Item listed as in stock wasn't there" },
+  { value: "incorrect_hours", label: "Hours wrong", hint: "Store hours look incorrect" },
+  { value: "wrong_price", label: "Price wrong", hint: "Posted price didn't match in-store" },
+  { value: "other", label: "Other", hint: "Anything else that seems off" },
+];
+
+type Props = {
+  storeId: string;
+  viewerRole: ViewerRole;
+};
+
+export default function StoreReportButton({ storeId, viewerRole }: Props) {
+  const [open, setOpen] = useState(false);
+  const [type, setType] = useState<ReportType>("out_of_stock");
+  const [comment, setComment] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [acknowledged, setAcknowledged] = useState(false);
+
+  const callbackPath = `/stores/${storeId}`;
+  const shopperLoginHref = `/shopper/login?callbackUrl=${encodeURIComponent(callbackPath)}`;
+
+  if (viewerRole !== "shopper") {
+    return (
+      <div className="rounded-xl border border-dashed border-gray-200 bg-white px-4 py-3 text-[13px] text-gray-600 flex flex-col sm:flex-row sm:items-center gap-2 sm:justify-between">
+        <span>See something wrong with this page?</span>
+        <Link
+          href={shopperLoginHref}
+          className="text-emerald-800 font-medium hover:underline"
+        >
+          Sign in as a shopper to report →
+        </Link>
+      </div>
+    );
+  }
+
+  async function submit() {
+    setSubmitting(true);
+    setError(null);
+    try {
+      const res = await fetch(`/api/stores/${storeId}/report`, {
+        method: "POST",
+        credentials: "include",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ type, comment: comment.trim() || undefined }),
+      });
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}));
+        throw new Error(data.error || "Could not submit report.");
+      }
+      setAcknowledged(true);
+      setComment("");
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Could not submit report.");
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  if (acknowledged) {
+    return (
+      <div className="rounded-xl bg-emerald-50 border border-emerald-100 px-4 py-3 text-[13px] text-emerald-900 flex items-center justify-between">
+        <span>Thanks — your report was submitted.</span>
+        <button
+          type="button"
+          onClick={() => {
+            setAcknowledged(false);
+            setOpen(false);
+          }}
+          className="text-emerald-800 font-medium hover:underline"
+        >
+          Dismiss
+        </button>
+      </div>
+    );
+  }
+
+  if (!open) {
+    return (
+      <button
+        type="button"
+        onClick={() => setOpen(true)}
+        className="inline-flex items-center gap-1.5 text-[12px] text-gray-500 hover:text-emerald-800 transition-colors"
+      >
+        <span aria-hidden>🚩</span>
+        Report incorrect info
+      </button>
+    );
+  }
+
+  return (
+    <div className="rounded-xl border border-gray-200 bg-white p-4 space-y-3">
+      <div className="flex items-start justify-between gap-2">
+        <div>
+          <p className="text-[14px] font-semibold text-gray-800">
+            Report incorrect info
+          </p>
+          <p className="text-[12px] text-gray-500 mt-0.5">
+            Quick tip to help us keep the platform trustworthy.
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={() => setOpen(false)}
+          className="text-gray-400 hover:text-gray-600 text-[16px]"
+          aria-label="Close report form"
+        >
+          ×
+        </button>
+      </div>
+      <div className="flex flex-wrap gap-2">
+        {TYPE_OPTIONS.map((opt) => (
+          <button
+            key={opt.value}
+            type="button"
+            title={opt.hint}
+            aria-pressed={type === opt.value}
+            onClick={() => setType(opt.value)}
+            className={`px-3 py-1.5 rounded-full text-[12px] font-semibold transition-colors ${
+              type === opt.value
+                ? "bg-emerald-700 text-white"
+                : "bg-gray-50 text-gray-700 hover:bg-gray-100 border border-gray-200"
+            }`}
+          >
+            {opt.label}
+          </button>
+        ))}
+      </div>
+      <textarea
+        maxLength={280}
+        rows={2}
+        value={comment}
+        onChange={(e) => setComment(e.target.value)}
+        placeholder="Optional — what did you see? (280 chars max)"
+        className="w-full rounded-lg border border-gray-200 px-3 py-2 text-[13px] focus:outline-none focus:ring-2 focus:ring-emerald-600/30"
+      />
+      {error && (
+        <p className="text-[12px] text-red-600" role="alert">
+          {error}
+        </p>
+      )}
+      <div className="flex items-center justify-end gap-2">
+        <button
+          type="button"
+          onClick={() => setOpen(false)}
+          className="px-3 py-1.5 text-[13px] text-gray-600 hover:text-gray-800"
+        >
+          Cancel
+        </button>
+        <button
+          type="button"
+          disabled={submitting}
+          onClick={submit}
+          className="px-4 py-1.5 rounded-lg text-[13px] font-semibold bg-emerald-700 text-white hover:bg-emerald-800 disabled:opacity-60"
+        >
+          {submitting ? "Sending…" : "Send report"}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/prisma/migrations/20260419120000_store_reports/migration.sql
+++ b/prisma/migrations/20260419120000_store_reports/migration.sql
@@ -1,0 +1,26 @@
+-- CreateEnum
+CREATE TYPE "StoreReportType" AS ENUM ('out_of_stock', 'incorrect_hours', 'wrong_price', 'other');
+
+-- CreateTable
+CREATE TABLE "store_reports" (
+    "id" TEXT NOT NULL,
+    "store_id" TEXT NOT NULL,
+    "shopper_id" TEXT NOT NULL,
+    "type" "StoreReportType" NOT NULL,
+    "comment" TEXT,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "store_reports_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "store_reports_store_id_created_at_idx" ON "store_reports"("store_id", "created_at");
+
+-- CreateIndex
+CREATE INDEX "store_reports_shopper_id_store_id_created_at_idx" ON "store_reports"("shopper_id", "store_id", "created_at");
+
+-- AddForeignKey
+ALTER TABLE "store_reports" ADD CONSTRAINT "store_reports_store_id_fkey" FOREIGN KEY ("store_id") REFERENCES "stores"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "store_reports" ADD CONSTRAINT "store_reports_shopper_id_fkey" FOREIGN KEY ("shopper_id") REFERENCES "shoppers"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -17,6 +17,13 @@ enum ShopperNotificationKind {
   store_new_deal
 }
 
+enum StoreReportType {
+  out_of_stock
+  incorrect_hours
+  wrong_price
+  other
+}
+
 model StoreOwner {
   id           String   @id @default(uuid())
   email        String   @unique
@@ -64,6 +71,7 @@ model Store {
   shopperNotifications ShopperNotification[]
   profileViews StoreProfileView[]
   itemSearches StoreItemSearch[]
+  reports      StoreReport[]
 
   @@map("stores")
 }
@@ -173,6 +181,7 @@ model Shopper {
 
   alerts Alert[]
   shopperNotifications ShopperNotification[]
+  reports StoreReport[]
 
   @@map("shoppers")
 }
@@ -210,6 +219,23 @@ model AuthAuditLog {
   @@index([ownerId, createdAt])
   @@index([emailHash, createdAt])
   @@map("auth_audit_logs")
+}
+
+/// Story 17: shopper-submitted reports of incorrect/outdated store info.
+model StoreReport {
+  id        String          @id @default(uuid())
+  storeId   String          @map("store_id")
+  shopperId String          @map("shopper_id")
+  type      StoreReportType
+  comment   String?
+  createdAt DateTime        @default(now()) @map("created_at")
+
+  store   Store   @relation(fields: [storeId], references: [id], onDelete: Cascade)
+  shopper Shopper @relation(fields: [shopperId], references: [id], onDelete: Cascade)
+
+  @@index([storeId, createdAt])
+  @@index([shopperId, storeId, createdAt])
+  @@map("store_reports")
 }
 
 model Alert {

--- a/tests/StoreReportButton.test.tsx
+++ b/tests/StoreReportButton.test.tsx
@@ -1,0 +1,121 @@
+/**
+ * Story 17 — Report incorrect info (#121)
+ *
+ * Covers the shopper-facing report button:
+ *   - Non-shopper viewers see the sign-in CTA instead of the form.
+ *   - Shoppers can open the form, pick a type chip, and submit.
+ *   - Submit POSTs to /api/stores/:id/report with the selected type.
+ *   - Successful submit swaps in the "Thanks — your report was submitted" ack.
+ *   - A 429 duplicate response surfaces the server's friendly error message.
+ *
+ * Tracking issue: #130
+ */
+import "@testing-library/jest-dom";
+import { act, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import React from "react";
+import StoreReportButton from "@/components/StoreReportButton";
+
+jest.mock("next/link", () => ({
+  __esModule: true,
+  default({ children, href }: { children: React.ReactNode; href: string }) {
+    return <a href={href}>{children}</a>;
+  },
+}));
+
+describe("StoreReportButton — viewer role gating", () => {
+  it("shows a sign-in CTA for logged-out viewers", () => {
+    render(<StoreReportButton storeId="store-1" viewerRole={null} />);
+    const link = screen.getByRole("link", { name: /sign in as a shopper/i });
+    expect(link).toBeInTheDocument();
+    expect(link.getAttribute("href")).toContain("/shopper/login");
+    expect(link.getAttribute("href")).toContain("callbackUrl=");
+  });
+
+  it("shows a sign-in CTA for owner viewers (wrong account type)", () => {
+    render(<StoreReportButton storeId="store-1" viewerRole="owner" />);
+    expect(
+      screen.getByRole("link", { name: /sign in as a shopper/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("renders the report trigger for shoppers", () => {
+    render(<StoreReportButton storeId="store-1" viewerRole="shopper" />);
+    expect(
+      screen.getByRole("button", { name: /report incorrect info/i }),
+    ).toBeInTheDocument();
+  });
+});
+
+describe("StoreReportButton — shopper flow", () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("submits the selected type and shows the acknowledgement", async () => {
+    const fetchMock = jest
+      .spyOn(global, "fetch")
+      .mockResolvedValue({
+        ok: true,
+        json: async () => ({ ok: true }),
+      } as Response);
+
+    render(<StoreReportButton storeId="store-42" viewerRole="shopper" />);
+    await userEvent.click(
+      screen.getByRole("button", { name: /report incorrect info/i }),
+    );
+
+    // Select a non-default chip to prove `type` flows through.
+    await userEvent.click(screen.getByRole("button", { name: /hours wrong/i }));
+
+    await act(async () => {
+      await userEvent.click(
+        screen.getByRole("button", { name: /send report/i }),
+      );
+    });
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        "/api/stores/store-42/report",
+        expect.objectContaining({ method: "POST" }),
+      );
+    });
+    const body = JSON.parse(
+      (fetchMock.mock.calls[0][1] as RequestInit).body as string,
+    );
+    expect(body).toEqual({ type: "incorrect_hours" });
+
+    expect(
+      await screen.findByText(/thanks — your report was submitted/i),
+    ).toBeInTheDocument();
+  });
+
+  it("surfaces the server error on 429 dedupe", async () => {
+    jest.spyOn(global, "fetch").mockResolvedValue({
+      ok: false,
+      status: 429,
+      json: async () => ({
+        error: "You already reported this store recently. Try again later.",
+      }),
+    } as Response);
+
+    render(<StoreReportButton storeId="store-42" viewerRole="shopper" />);
+    await userEvent.click(
+      screen.getByRole("button", { name: /report incorrect info/i }),
+    );
+
+    await act(async () => {
+      await userEvent.click(
+        screen.getByRole("button", { name: /send report/i }),
+      );
+    });
+
+    expect(
+      await screen.findByText(/already reported this store recently/i),
+    ).toBeInTheDocument();
+    // Still in form, not acknowledged.
+    expect(
+      screen.queryByText(/thanks — your report was submitted/i),
+    ).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
Closes #121

## Summary
Adds a lightweight way for shoppers to flag incorrect/outdated store
info so owners can fix it.

- Prisma model `StoreReport` + enum `StoreReportType` (`out_of_stock`,
  `incorrect_hours`, `wrong_price`, `other`) + migration.
- `POST /api/stores/[id]/report` — shopper auth required, 280-char
  comment cap, 24-hour duplicate guard per (shopper, store) returning
  **429** (spec says "blocked"; we surface an actionable status rather
  than 409 since this is rate-limit-shaped).
- `GET /api/stores/[id]/reports` — owner-only, own-store-only.
- `StoreReportButton` client island on `/stores/[id]`: type chips +
  optional comment, in-place acknowledgement.
- `/dashboard/reports` page + sidebar entry for owners.

## Machine acceptance criteria
- [x] `POST /stores/:id/report` stores `{type, comment?, user_id, store_id}`.
- [x] Duplicate reports from the same user within 24h are blocked.
- [x] Owners can view reports via `/dashboard/reports`.

## Human acceptance criteria
- [x] Submit in under 15 seconds (single inline form, 4 type chips).
- [x] Lightweight, not punitive tone.
- [x] Confirmation message after submission.

## Automation note
Implemented via Claude Code (Opus 4.7) as part of P4 task 3. Prompt/procedure documented in the P4 PDF.

🤖 Generated with [Claude Code](https://claude.com/claude-code)