### PR TITLE
US15: Shopper-facing store ratings (#119)

### DIFF
--- a/app/(public)/stores/[id]/page.tsx
+++ b/app/(public)/stores/[id]/page.tsx
@@ -18,6 +18,7 @@ import Link from "next/link";
 import ItemAvailabilitySearch from "@/components/ItemAvailabilitySearch";
 import StoreAlertSubscribe from "@/components/StoreAlertSubscribe";
 import StoreFreshUpdatesFeed from "@/components/StoreFreshUpdatesFeed";
+import StoreRatingsPanel from "@/components/StoreRatingsPanel";
 
 export const dynamic = "force-dynamic";
 
@@ -82,6 +83,58 @@ export default async function StoreProfilePage({
     });
     initialStoreFollow = Boolean(follow);
     storeFollowAlertId = follow?.id ?? null;
+  }
+
+  const RATINGS_PAGE_SIZE = 10;
+  const [ratingAgg, recentRatings] = await Promise.all([
+    prisma.storeRating.aggregate({
+      where: { storeId: id },
+      _avg: { score: true },
+      _count: { _all: true },
+    }),
+    prisma.storeRating.findMany({
+      where: { storeId: id },
+      orderBy: { createdAt: "desc" },
+      take: RATINGS_PAGE_SIZE,
+      select: {
+        id: true,
+        score: true,
+        note: true,
+        createdAt: true,
+        shopper: { select: { name: true } },
+      },
+    }),
+  ]);
+
+  const ratingsSummary = {
+    average:
+      ratingAgg._avg.score != null
+        ? Math.round(ratingAgg._avg.score * 10) / 10
+        : null,
+    total: ratingAgg._count._all,
+    ratings: recentRatings.map((r) => ({
+      id: r.id,
+      score: r.score,
+      note: r.note,
+      createdAt: r.createdAt.toISOString(),
+      authorName: r.shopper.name,
+    })),
+    hasMore: ratingAgg._count._all > RATINGS_PAGE_SIZE,
+  };
+
+  let initialOwnRating: {
+    id: string;
+    score: number;
+    note: string | null;
+  } | null = null;
+  if (session?.role === "shopper") {
+    const own = await prisma.storeRating.findUnique({
+      where: {
+        storeId_shopperId: { storeId: id, shopperId: session.user.id },
+      },
+      select: { id: true, score: true, note: true },
+    });
+    if (own) initialOwnRating = own;
   }
 
   const freshUpdatesDisplay = enrichFreshUpdatesWithStale(
@@ -193,6 +246,14 @@ export default async function StoreProfilePage({
         storeName={store.name}
         storeAddress={store.address}
         viewerRole={viewerRole}
+      />
+
+      {/* Shopper ratings — Story 15 */}
+      <StoreRatingsPanel
+        storeId={store.id}
+        viewerRole={viewerRole}
+        initialSummary={ratingsSummary}
+        initialOwnRating={initialOwnRating}
       />
 
       {/* Fresh Today — Story 1 */}

--- a/app/api/stores/[id]/ratings/[ratingId]/route.ts
+++ b/app/api/stores/[id]/ratings/[ratingId]/route.ts
@@ -1,0 +1,31 @@
+// Story 15: A shopper may delete their own rating only.
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { requireShopperSession } from "@/lib/require-shopper-session";
+
+export async function DELETE(
+  _req: NextRequest,
+  ctx: { params: Promise<{ id: string; ratingId: string }> },
+) {
+  const gate = await requireShopperSession();
+  if (!gate.ok) return gate.response;
+  const { session } = gate;
+  const { id: storeId, ratingId } = await ctx.params;
+
+  const rating = await prisma.storeRating.findUnique({
+    where: { id: ratingId },
+    select: { id: true, shopperId: true, storeId: true },
+  });
+  if (!rating || rating.storeId !== storeId) {
+    return NextResponse.json({ error: "Rating not found" }, { status: 404 });
+  }
+  if (rating.shopperId !== session.user.id) {
+    return NextResponse.json(
+      { error: "You can only delete your own rating." },
+      { status: 403 },
+    );
+  }
+
+  await prisma.storeRating.delete({ where: { id: ratingId } });
+  return NextResponse.json({ ok: true });
+}

--- a/app/api/stores/[id]/ratings/route.ts
+++ b/app/api/stores/[id]/ratings/route.ts
@@ -30,19 +30,31 @@ export async function GET(
     _count: { _all: true },
   });
 
-  const ratings = await prisma.storeRating.findMany({
-    where: { storeId },
-    orderBy: { createdAt: "desc" },
-    skip: (page - 1) * PAGE_SIZE,
-    take: PAGE_SIZE,
-    select: {
-      id: true,
-      score: true,
-      note: true,
-      createdAt: true,
-      shopper: { select: { name: true } },
-    },
-  });
+  // The paginated feed is "recent notes" — only ratings that carried a
+  // written note. `total` still reflects all ratings (used for the "X
+  // ratings" header count), but pagination/hasMore tracks notes only.
+  const noteWhere = {
+    storeId,
+    note: { not: null },
+    NOT: { note: "" },
+  } as const;
+
+  const [notesCount, ratings] = await Promise.all([
+    prisma.storeRating.count({ where: noteWhere }),
+    prisma.storeRating.findMany({
+      where: noteWhere,
+      orderBy: { createdAt: "desc" },
+      skip: (page - 1) * PAGE_SIZE,
+      take: PAGE_SIZE,
+      select: {
+        id: true,
+        score: true,
+        note: true,
+        createdAt: true,
+        shopper: { select: { name: true } },
+      },
+    }),
+  ]);
 
   const total = agg._count._all;
   const average =
@@ -53,7 +65,7 @@ export async function GET(
     total,
     page,
     pageSize: PAGE_SIZE,
-    hasMore: page * PAGE_SIZE < total,
+    hasMore: page * PAGE_SIZE < notesCount,
     ratings: ratings.map((r) => ({
       id: r.id,
       score: r.score,

--- a/app/api/stores/[id]/ratings/route.ts
+++ b/app/api/stores/[id]/ratings/route.ts
@@ -1,0 +1,143 @@
+// Story 15: Shopper-facing store ratings.
+// - GET is public; returns aggregate + paginated recent notes.
+// - POST requires a shopper session; one rating per (store, shopper).
+import { NextRequest, NextResponse } from "next/server";
+import { Prisma } from "@/app/generated/prisma/client";
+import { prisma } from "@/lib/prisma";
+import { requireShopperSession } from "@/lib/require-shopper-session";
+
+const PAGE_SIZE = 10;
+const NOTE_MAX = 280;
+
+export async function GET(
+  req: NextRequest,
+  ctx: { params: Promise<{ id: string }> },
+) {
+  const { id: storeId } = await ctx.params;
+  const page = Math.max(1, parseInt(req.nextUrl.searchParams.get("page") ?? "1", 10) || 1);
+
+  const store = await prisma.store.findUnique({
+    where: { id: storeId },
+    select: { id: true },
+  });
+  if (!store) {
+    return NextResponse.json({ error: "Store not found" }, { status: 404 });
+  }
+
+  const agg = await prisma.storeRating.aggregate({
+    where: { storeId },
+    _avg: { score: true },
+    _count: { _all: true },
+  });
+
+  const ratings = await prisma.storeRating.findMany({
+    where: { storeId },
+    orderBy: { createdAt: "desc" },
+    skip: (page - 1) * PAGE_SIZE,
+    take: PAGE_SIZE,
+    select: {
+      id: true,
+      score: true,
+      note: true,
+      createdAt: true,
+      shopper: { select: { name: true } },
+    },
+  });
+
+  const total = agg._count._all;
+  const average =
+    agg._avg.score != null ? Math.round(agg._avg.score * 10) / 10 : null;
+
+  return NextResponse.json({
+    average,
+    total,
+    page,
+    pageSize: PAGE_SIZE,
+    hasMore: page * PAGE_SIZE < total,
+    ratings: ratings.map((r) => ({
+      id: r.id,
+      score: r.score,
+      note: r.note,
+      createdAt: r.createdAt,
+      authorName: r.shopper.name,
+    })),
+  });
+}
+
+export async function POST(
+  req: NextRequest,
+  ctx: { params: Promise<{ id: string }> },
+) {
+  const gate = await requireShopperSession();
+  if (!gate.ok) return gate.response;
+  const { session } = gate;
+  const { id: storeId } = await ctx.params;
+
+  const body = await req.json().catch(() => null);
+  const score = body?.score;
+  const noteRaw = body?.note;
+
+  if (
+    typeof score !== "number" ||
+    !Number.isInteger(score) ||
+    score < 1 ||
+    score > 5
+  ) {
+    return NextResponse.json(
+      { error: "score must be an integer between 1 and 5" },
+      { status: 400 },
+    );
+  }
+  let note: string | null = null;
+  if (noteRaw != null) {
+    if (typeof noteRaw !== "string") {
+      return NextResponse.json(
+        { error: "note must be a string" },
+        { status: 400 },
+      );
+    }
+    const trimmed = noteRaw.trim();
+    if (trimmed.length > NOTE_MAX) {
+      return NextResponse.json(
+        { error: `note too long (max ${NOTE_MAX} characters)` },
+        { status: 400 },
+      );
+    }
+    note = trimmed || null;
+  }
+
+  const store = await prisma.store.findUnique({
+    where: { id: storeId },
+    select: { id: true },
+  });
+  if (!store) {
+    return NextResponse.json({ error: "Store not found" }, { status: 404 });
+  }
+
+  try {
+    const rating = await prisma.storeRating.create({
+      data: {
+        storeId,
+        shopperId: session.user.id,
+        score,
+        note,
+      },
+      select: { id: true, score: true, note: true, createdAt: true },
+    });
+    return NextResponse.json({ rating }, { status: 201 });
+  } catch (err) {
+    if (
+      err instanceof Prisma.PrismaClientKnownRequestError &&
+      err.code === "P2002"
+    ) {
+      return NextResponse.json(
+        {
+          error:
+            "You've already rated this store. Delete your rating first to submit a new one.",
+        },
+        { status: 409 },
+      );
+    }
+    throw err;
+  }
+}

--- a/components/StoreRatingsPanel.tsx
+++ b/components/StoreRatingsPanel.tsx
@@ -98,17 +98,22 @@ export default function StoreRatingsPanel({
       const res = await fetch(`/api/stores/${storeId}/ratings`, {
         cache: "no-store",
       });
-      if (res.ok) {
-        const data = await res.json();
-        setSummary({
-          average: data.average,
-          total: data.total,
-          ratings: data.ratings,
-          hasMore: data.hasMore,
-        });
+      if (!res.ok) {
+        throw new Error("Could not refresh ratings.");
       }
-    } catch {
-      /* ignore */
+      const data = await res.json();
+      setSummary({
+        average: data.average,
+        total: data.total,
+        ratings: data.ratings,
+        hasMore: data.hasMore,
+      });
+    } catch (e) {
+      setError(
+        e instanceof Error
+          ? `${e.message} You may need to reload the page.`
+          : "Could not refresh ratings. You may need to reload the page.",
+      );
     }
   }
 

--- a/components/StoreRatingsPanel.tsx
+++ b/components/StoreRatingsPanel.tsx
@@ -1,0 +1,298 @@
+// Story 15: Shopper-facing lightweight rating + tip panel on a store page.
+"use client";
+
+import Link from "next/link";
+import { useEffect, useState } from "react";
+import type { ViewerRole } from "@/lib/viewer-role";
+
+type RatingItem = {
+  id: string;
+  score: number;
+  note: string | null;
+  createdAt: string;
+  authorName: string;
+};
+
+type Summary = {
+  average: number | null;
+  total: number;
+  ratings: RatingItem[];
+  hasMore: boolean;
+};
+
+type OwnRating = {
+  id: string;
+  score: number;
+  note: string | null;
+} | null;
+
+type Props = {
+  storeId: string;
+  viewerRole: ViewerRole;
+  initialSummary: Summary;
+  /** Own rating if the viewer is a shopper who has already rated. */
+  initialOwnRating: OwnRating;
+};
+
+function Stars({ score, onPick }: { score: number; onPick?: (n: number) => void }) {
+  return (
+    <div className="flex items-center gap-0.5" role="group" aria-label="Rating stars">
+      {[1, 2, 3, 4, 5].map((n) => {
+        const filled = n <= score;
+        const interactive = typeof onPick === "function";
+        const className = `text-[20px] leading-none ${
+          filled ? "text-amber-500" : "text-gray-300"
+        } ${interactive ? "hover:scale-110 transition-transform" : ""}`;
+        if (interactive) {
+          return (
+            <button
+              key={n}
+              type="button"
+              aria-label={`${n} star${n > 1 ? "s" : ""}`}
+              aria-pressed={filled}
+              onClick={() => onPick?.(n)}
+              className={className}
+            >
+              ★
+            </button>
+          );
+        }
+        return (
+          <span key={n} aria-hidden className={className}>
+            ★
+          </span>
+        );
+      })}
+    </div>
+  );
+}
+
+function formatDate(iso: string) {
+  return new Intl.DateTimeFormat("en-US", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  }).format(new Date(iso));
+}
+
+export default function StoreRatingsPanel({
+  storeId,
+  viewerRole,
+  initialSummary,
+  initialOwnRating,
+}: Props) {
+  const [summary, setSummary] = useState<Summary>(initialSummary);
+  const [ownRating, setOwnRating] = useState<OwnRating>(initialOwnRating);
+  const [score, setScore] = useState(0);
+  const [note, setNote] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    setSummary(initialSummary);
+    setOwnRating(initialOwnRating);
+  }, [initialSummary, initialOwnRating, storeId]);
+
+  async function refresh() {
+    try {
+      const res = await fetch(`/api/stores/${storeId}/ratings`, {
+        cache: "no-store",
+      });
+      if (res.ok) {
+        const data = await res.json();
+        setSummary({
+          average: data.average,
+          total: data.total,
+          ratings: data.ratings,
+          hasMore: data.hasMore,
+        });
+      }
+    } catch {
+      /* ignore */
+    }
+  }
+
+  async function submit() {
+    setError(null);
+    if (score < 1 || score > 5) {
+      setError("Pick 1–5 stars first.");
+      return;
+    }
+    setSubmitting(true);
+    try {
+      const res = await fetch(`/api/stores/${storeId}/ratings`, {
+        method: "POST",
+        credentials: "include",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ score, note: note.trim() || undefined }),
+      });
+      const data = await res.json().catch(() => ({}));
+      if (!res.ok) {
+        throw new Error(data.error || "Could not submit rating.");
+      }
+      setOwnRating({
+        id: data.rating.id,
+        score: data.rating.score,
+        note: data.rating.note,
+      });
+      setScore(0);
+      setNote("");
+      refresh();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Could not submit rating.");
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  async function deleteOwn() {
+    if (!ownRating) return;
+    setSubmitting(true);
+    setError(null);
+    try {
+      const res = await fetch(
+        `/api/stores/${storeId}/ratings/${ownRating.id}`,
+        { method: "DELETE", credentials: "include" },
+      );
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}));
+        throw new Error(data.error || "Could not delete rating.");
+      }
+      setOwnRating(null);
+      refresh();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Could not delete rating.");
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  const callbackPath = `/stores/${storeId}`;
+  const shopperLoginHref = `/shopper/login?callbackUrl=${encodeURIComponent(callbackPath)}`;
+
+  return (
+    <section
+      className="bg-white rounded-2xl border border-gray-200 p-6 mb-4 space-y-4"
+      aria-labelledby="ratings-heading"
+    >
+      <div className="flex items-center justify-between gap-3 flex-wrap">
+        <h2
+          id="ratings-heading"
+          className="text-[17px] font-semibold text-gray-800 flex items-center gap-2"
+        >
+          <span aria-hidden>⭐</span>
+          Shopper ratings
+        </h2>
+        <div className="text-[13px] text-gray-500 flex items-center gap-2">
+          {summary.average != null ? (
+            <>
+              <Stars score={Math.round(summary.average)} />
+              <span className="font-semibold text-gray-800">
+                {summary.average.toFixed(1)}
+              </span>
+              <span>
+                ({summary.total} {summary.total === 1 ? "rating" : "ratings"})
+              </span>
+            </>
+          ) : (
+            <span>No ratings yet. Be the first!</span>
+          )}
+        </div>
+      </div>
+
+      {viewerRole === "shopper" ? (
+        ownRating ? (
+          <div className="rounded-xl bg-emerald-50/60 border border-emerald-100 p-4">
+            <p className="text-[12px] font-semibold text-emerald-900 uppercase tracking-wider">
+              Your rating
+            </p>
+            <div className="mt-1 flex items-center gap-2">
+              <Stars score={ownRating.score} />
+              <span className="text-[13px] text-gray-600">
+                {ownRating.score}/5
+              </span>
+            </div>
+            {ownRating.note ? (
+              <p className="mt-2 text-[14px] text-gray-700 leading-relaxed">
+                {ownRating.note}
+              </p>
+            ) : null}
+            <button
+              type="button"
+              onClick={deleteOwn}
+              disabled={submitting}
+              className="mt-3 text-[12px] font-medium text-red-600 hover:text-red-800 disabled:opacity-60"
+            >
+              Delete my rating
+            </button>
+            {error && (
+              <p className="mt-2 text-[12px] text-red-600" role="alert">
+                {error}
+              </p>
+            )}
+          </div>
+        ) : (
+          <div className="rounded-xl border border-gray-200 p-4 space-y-2">
+            <p className="text-[13px] text-gray-600">
+              Leave a quick rating (and optional tip, 280 chars max):
+            </p>
+            <Stars score={score} onPick={setScore} />
+            <textarea
+              maxLength={280}
+              rows={2}
+              value={note}
+              onChange={(e) => setNote(e.target.value)}
+              placeholder="Optional — a quick tip for other shoppers"
+              className="w-full rounded-lg border border-gray-200 px-3 py-2 text-[13px] focus:outline-none focus:ring-2 focus:ring-emerald-600/30"
+            />
+            {error && (
+              <p className="text-[12px] text-red-600" role="alert">
+                {error}
+              </p>
+            )}
+            <div className="flex justify-end">
+              <button
+                type="button"
+                disabled={submitting || score < 1}
+                onClick={submit}
+                className="px-4 py-1.5 rounded-lg text-[13px] font-semibold bg-emerald-700 text-white hover:bg-emerald-800 disabled:opacity-60"
+              >
+                {submitting ? "Submitting…" : "Submit rating"}
+              </button>
+            </div>
+          </div>
+        )
+      ) : (
+        <div className="rounded-xl border border-dashed border-gray-200 p-3 text-[13px] text-gray-600">
+          <Link
+            href={shopperLoginHref}
+            className="text-emerald-800 font-medium hover:underline"
+          >
+            Sign in as a shopper
+          </Link>{" "}
+          to leave a rating.
+        </div>
+      )}
+
+      {summary.ratings.length > 0 && (
+        <ul className="divide-y divide-gray-100 pt-1">
+          {summary.ratings.map((r) => (
+            <li key={r.id} className="py-3">
+              <div className="flex items-center gap-2">
+                <Stars score={r.score} />
+                <span className="text-[12px] text-gray-400">
+                  {r.authorName} · {formatDate(r.createdAt)}
+                </span>
+              </div>
+              {r.note ? (
+                <p className="mt-1 text-[14px] text-gray-700 leading-relaxed">
+                  {r.note}
+                </p>
+              ) : null}
+            </li>
+          ))}
+        </ul>
+      )}
+    </section>
+  );
+}

--- a/prisma/migrations/20260419130000_store_ratings/migration.sql
+++ b/prisma/migrations/20260419130000_store_ratings/migration.sql
@@ -1,0 +1,24 @@
+-- CreateTable
+CREATE TABLE "store_ratings" (
+    "id" TEXT NOT NULL,
+    "store_id" TEXT NOT NULL,
+    "shopper_id" TEXT NOT NULL,
+    "score" INTEGER NOT NULL,
+    "note" TEXT,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "store_ratings_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "store_ratings_store_id_shopper_id_key" ON "store_ratings"("store_id", "shopper_id");
+
+-- CreateIndex
+CREATE INDEX "store_ratings_store_id_created_at_idx" ON "store_ratings"("store_id", "created_at" DESC);
+
+-- AddForeignKey
+ALTER TABLE "store_ratings" ADD CONSTRAINT "store_ratings_store_id_fkey" FOREIGN KEY ("store_id") REFERENCES "stores"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "store_ratings" ADD CONSTRAINT "store_ratings_shopper_id_fkey" FOREIGN KEY ("shopper_id") REFERENCES "shoppers"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/migrations/20260419140000_store_ratings_score_check/migration.sql
+++ b/prisma/migrations/20260419140000_store_ratings_score_check/migration.sql
@@ -1,0 +1,4 @@
+-- Enforce the 1–5 star range at the database layer so a buggy caller
+-- (or direct SQL) can't insert an out-of-range score.
+ALTER TABLE "store_ratings"
+  ADD CONSTRAINT "store_ratings_score_range" CHECK ("score" BETWEEN 1 AND 5);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -64,6 +64,7 @@ model Store {
   shopperNotifications ShopperNotification[]
   profileViews StoreProfileView[]
   itemSearches StoreItemSearch[]
+  ratings      StoreRating[]
 
   @@map("stores")
 }
@@ -173,6 +174,7 @@ model Shopper {
 
   alerts Alert[]
   shopperNotifications ShopperNotification[]
+  ratings StoreRating[]
 
   @@map("shoppers")
 }
@@ -210,6 +212,25 @@ model AuthAuditLog {
   @@index([ownerId, createdAt])
   @@index([emailHash, createdAt])
   @@map("auth_audit_logs")
+}
+
+/// Story 15: lightweight shopper rating (1–5) + optional tip per store.
+/// Unique per (store, shopper) so a shopper can hold at most one active rating.
+model StoreRating {
+  id        String   @id @default(uuid())
+  storeId   String   @map("store_id")
+  shopperId String   @map("shopper_id")
+  score     Int
+  note      String?
+  createdAt DateTime @default(now()) @map("created_at")
+  updatedAt DateTime @updatedAt @map("updated_at")
+
+  store   Store   @relation(fields: [storeId], references: [id], onDelete: Cascade)
+  shopper Shopper @relation(fields: [shopperId], references: [id], onDelete: Cascade)
+
+  @@unique([storeId, shopperId])
+  @@index([storeId, createdAt(sort: Desc)])
+  @@map("store_ratings")
 }
 
 model Alert {

--- a/tests/StoreRatingsPanel.test.tsx
+++ b/tests/StoreRatingsPanel.test.tsx
@@ -1,0 +1,196 @@
+/**
+ * Story 15 — Shopper ratings (#119)
+ *
+ * Covers the ratings panel on the store profile:
+ *   - Aggregate header renders average + total when ratings exist, and a
+ *     "no ratings yet" copy otherwise.
+ *   - Logged-out viewers see the sign-in CTA.
+ *   - Shoppers without an existing rating can pick stars, submit, and see
+ *     their rating appear in the "Your rating" card.
+ *   - Shoppers with an existing rating can delete it, which hits
+ *     DELETE /api/stores/:id/ratings/:ratingId and restores the form.
+ *
+ * Tracking issue: #128
+ */
+import "@testing-library/jest-dom";
+import { act, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import React from "react";
+import StoreRatingsPanel from "@/components/StoreRatingsPanel";
+
+jest.mock("next/link", () => ({
+  __esModule: true,
+  default({ children, href }: { children: React.ReactNode; href: string }) {
+    return <a href={href}>{children}</a>;
+  },
+}));
+
+const EMPTY_SUMMARY = {
+  average: null,
+  total: 0,
+  ratings: [],
+  hasMore: false,
+};
+
+const POPULATED_SUMMARY = {
+  average: 4.3,
+  total: 12,
+  ratings: [
+    {
+      id: "r-1",
+      score: 5,
+      note: "Best produce in Bloomfield.",
+      createdAt: "2026-04-01T12:00:00.000Z",
+      authorName: "Alex",
+    },
+  ],
+  hasMore: false,
+};
+
+describe("StoreRatingsPanel — aggregate header", () => {
+  it("shows 'no ratings yet' when average is null", () => {
+    render(
+      <StoreRatingsPanel
+        storeId="s1"
+        viewerRole={null}
+        initialSummary={EMPTY_SUMMARY}
+        initialOwnRating={null}
+      />,
+    );
+    expect(screen.getByText(/no ratings yet/i)).toBeInTheDocument();
+  });
+
+  it("shows the average and total when ratings exist", () => {
+    render(
+      <StoreRatingsPanel
+        storeId="s1"
+        viewerRole={null}
+        initialSummary={POPULATED_SUMMARY}
+        initialOwnRating={null}
+      />,
+    );
+    expect(screen.getByText("4.3")).toBeInTheDocument();
+    expect(screen.getByText(/12 ratings/i)).toBeInTheDocument();
+    expect(screen.getByText(/best produce in bloomfield/i)).toBeInTheDocument();
+  });
+});
+
+describe("StoreRatingsPanel — viewer-role gating", () => {
+  it("shows a sign-in CTA for logged-out viewers", () => {
+    render(
+      <StoreRatingsPanel
+        storeId="s1"
+        viewerRole={null}
+        initialSummary={EMPTY_SUMMARY}
+        initialOwnRating={null}
+      />,
+    );
+    const link = screen.getByRole("link", { name: /sign in as a shopper/i });
+    expect(link.getAttribute("href")).toContain("/shopper/login");
+  });
+
+  it("shows the same CTA for owner viewers", () => {
+    render(
+      <StoreRatingsPanel
+        storeId="s1"
+        viewerRole="owner"
+        initialSummary={EMPTY_SUMMARY}
+        initialOwnRating={null}
+      />,
+    );
+    expect(
+      screen.getByRole("link", { name: /sign in as a shopper/i }),
+    ).toBeInTheDocument();
+  });
+});
+
+describe("StoreRatingsPanel — shopper submit flow", () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("POSTs the selected score and renders 'Your rating' on success", async () => {
+    const fetchMock = jest.spyOn(global, "fetch").mockImplementation(
+      async (input: RequestInfo | URL, init?: RequestInit) => {
+        if (init?.method === "POST") {
+          return {
+            ok: true,
+            json: async () => ({
+              rating: { id: "new-1", score: 4, note: "solid" },
+            }),
+          } as Response;
+        }
+        return { ok: true, json: async () => POPULATED_SUMMARY } as Response;
+      },
+    );
+
+    render(
+      <StoreRatingsPanel
+        storeId="s1"
+        viewerRole="shopper"
+        initialSummary={EMPTY_SUMMARY}
+        initialOwnRating={null}
+      />,
+    );
+
+    await userEvent.click(screen.getByRole("button", { name: /4 stars/i }));
+    await act(async () => {
+      await userEvent.click(
+        screen.getByRole("button", { name: /submit rating/i }),
+      );
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText(/your rating/i)).toBeInTheDocument();
+    });
+    expect(screen.getByText("4/5")).toBeInTheDocument();
+
+    const postCall = fetchMock.mock.calls.find(
+      ([, init]) => (init as RequestInit | undefined)?.method === "POST",
+    );
+    expect(postCall).toBeTruthy();
+    expect(postCall?.[0]).toBe("/api/stores/s1/ratings");
+    expect(JSON.parse((postCall?.[1] as RequestInit).body as string)).toEqual({
+      score: 4,
+    });
+  });
+
+  it("deletes the shopper's own rating via DELETE", async () => {
+    const fetchMock = jest.spyOn(global, "fetch").mockImplementation(
+      async (_input: RequestInfo | URL, init?: RequestInit) => {
+        if (init?.method === "DELETE") {
+          return { ok: true, json: async () => ({}) } as Response;
+        }
+        return { ok: true, json: async () => EMPTY_SUMMARY } as Response;
+      },
+    );
+
+    render(
+      <StoreRatingsPanel
+        storeId="s1"
+        viewerRole="shopper"
+        initialSummary={POPULATED_SUMMARY}
+        initialOwnRating={{ id: "mine-1", score: 5, note: "love it" }}
+      />,
+    );
+
+    expect(screen.getByText(/your rating/i)).toBeInTheDocument();
+
+    await act(async () => {
+      await userEvent.click(
+        screen.getByRole("button", { name: /delete my rating/i }),
+      );
+    });
+
+    const deleteCall = fetchMock.mock.calls.find(
+      ([, init]) => (init as RequestInit | undefined)?.method === "DELETE",
+    );
+    expect(deleteCall?.[0]).toBe("/api/stores/s1/ratings/mine-1");
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: /submit rating/i }),
+      ).toBeInTheDocument();
+    });
+  });
+});


### PR DESCRIPTION
Closes #119

## Summary
Lightweight 1–5 rating + optional 280-char note per shopper per store.
Aggregates are public; write/delete require a shopper session.

- Prisma model \`StoreRating\` with \`@@unique([storeId, shopperId])\` so a shopper holds at most one rating per store.
- \`GET /api/stores/[id]/ratings\` — public, returns \`{average, total, hasMore, ratings:[…]}\`; 10 per page via \`?page=\`.
- \`POST /api/stores/[id]/ratings\` — shopper-only; **400** on missing/out-of-range score; **409** on duplicate (P2002 → message tells the shopper to delete first); **201** on success.
- \`DELETE /api/stores/[id]/ratings/[ratingId]\` — shopper-only; **403** if the rating belongs to another shopper; **404** if mismatched store.
- \`StoreRatingsPanel\` island on \`/stores/[id]\` — star picker, optional note, \"Your rating\" card with delete, recent notes list. Initial aggregate + own rating are fetched server-side to avoid layout shift.

## Machine acceptance criteria
- [x] 1–5 score required, optional 280-char note.
- [x] Duplicate → 409; unauth POST/DELETE → 401; GET public.
- [x] Average + total + paginated notes (10/page) returned.
- [x] DELETE of someone else's rating → 403.

## Human acceptance criteria
- [x] Rate in under 30 s from the store page (inline panel, 5 stars, optional note).
- [x] Public visitors see aggregate.
- [x] Already-rated shoppers see their own rating with Delete (no second submit form).

## Automation note
Implemented via Claude Code (Opus 4.7) as part of P4 task 3. Prompt/procedure documented in the P4 PDF.

🤖 Generated with [Claude Code](https://claude.com/claude-code)