### PR TITLE
docs: P4 code-generation procedure

### DIFF
--- a/docs/p4-code-generation-procedure.md
+++ b/docs/p4-code-generation-procedure.md
@@ -116,6 +116,56 @@ the same for every story — only the issue body changes.
 > When uncertain between two reasonable designs, pick the simpler one and
 > note the tradeoff in the PR body. Do not merge — a human reviews.
 
+## System prompt used for debugging
+
+Once a PR is open, the developer watches CI. When a check fails, paste
+the following prompt to the agent along with the PR number. The agent
+is already authenticated with `gh` (see **Tooling**), so it can pull
+the failing logs on its own — the human does *not* need to copy the
+log output into chat.
+
+> `PR #<N>` for `US <X>` failed its CI checks — please fix it.
+>
+> Follow this loop:
+>
+> 1. **Pull the failing signal directly.** Run
+>    `gh pr checks <N> --repo <owner>/<repo>` to see which job failed,
+>    then `gh run view <run-id> --repo <owner>/<repo> --log-failed` to
+>    read the actual failure. Do not ask me to paste logs.
+> 2. **Diagnose before editing.** Identify the specific assertion,
+>    compile error, lint rule, or type that failed. Tie the failure to
+>    a single cause. If tests fail, read the test file — never "fix" by
+>    changing the test unless the test itself is clearly wrong *and*
+>    you say so explicitly.
+> 3. **Respect the test contract.** Existing tests encode behavior
+>    contracts from earlier stories. If your change broke one, the
+>    default assumption is that your change is wrong, not the test.
+>    Restore the contract while keeping the new feature.
+> 4. **Make the smallest diff that turns the check green.** No drive-by
+>    refactors, no reformatting, no new abstractions. If you need to
+>    touch more than the failing surface, explain why in the commit
+>    message.
+> 5. **Re-run the failing job locally before pushing.** For Jest, run
+>    the exact file (`npx jest tests/<file>`); for type-check, run
+>    `npx tsc --noEmit`; for lint, run `npm run lint`. Only push if it
+>    passes locally.
+> 6. **Push to the same branch, don't open a new PR.** Commit message
+>    form: `fix(us<X>): <what you changed> — <why CI failed>`.
+> 7. **Watch the re-run.** `gh pr checks <N> --repo <owner>/<repo> --watch`.
+>    If it fails again, go back to step 1. Do not amend or force-push
+>    without explicit human approval.
+>
+> Do not merge the PR, and do not mark the issue as fixed in the PR
+> description — a human reviews and merges.
+
+This prompt was used to fix `PR #124` (US16) after the `MapPage` test
+regressed because the empty-state copy changed: the agent read the
+failing log via `gh run view … --log-failed`, identified the single
+broken assertion in `tests/MapPage.test.tsx`, restored the original
+"Finding stores near you…" string for the unfiltered empty case while
+keeping the new "No stores match the selected filters." copy for the
+filtered empty case, and pushed one commit (`036b33c`).
+
 ## Story-level notes
 
 ### US15 — Shopper ratings (#119)

--- a/docs/p4-code-generation-procedure.md
+++ b/docs/p4-code-generation-procedure.md
@@ -1,0 +1,161 @@
+# P4 Task 3 — Automated Code Generation Procedure
+
+This document describes the repeatable workflow we use to drive code
+generation for a new user story with an LLM agent. It is the procedure
+we followed for stories **#119 (US15 ratings)**, **#120 (US16 map
+filters)**, and **#121 (US17 reports)**.
+
+## Tooling
+
+- **Agent**: Claude Code (Opus 4.7) — CLI coding agent with repo read/write,
+  shell access, and `gh` CLI access.
+- **VCS**: GitHub; one issue-per-story, one branch-per-story, one PR-per-story.
+- **Auth for the agent**: `gh auth` backed by the developer's keychain
+  GitHub token (`gho_…`). The agent exports `GH_TOKEN` per invocation so
+  `gh api` / `gh pr create` work without interactive login.
+
+## Repeatable steps
+
+Given a story tracked in a GitHub issue `#N`, the agent runs the following
+ordered steps. The steps are identical across stories; only the prompt and
+resulting code differ.
+
+1. **Load the issue**
+   ```
+   gh api repos/<owner>/<repo>/issues/N
+   ```
+   Extract title, body, human and machine acceptance criteria.
+
+2. **Ground in the codebase**
+   Read the files the story most likely touches:
+   - `prisma/schema.prisma` (if new data is needed)
+   - `app/api/stores/[id]/*` and nearby API routes as pattern references
+   - `lib/require-shopper-session.ts` / `lib/require-owner-session.ts`
+     for auth-gating
+   - The relevant page under `app/(public)` or `app/(dashboard)`
+   - The sidebar / nav components if owner surfaces are added
+
+3. **Branch off `main`**
+   ```
+   git fetch origin main
+   git checkout -b feature/us-<n>-<slug> origin/main
+   ```
+
+4. **Generate code** using the *system prompt* below, pasting the issue
+   body verbatim as context.
+
+5. **Quality gate (local)**
+   - Confirm new files compile against existing types (pre-existing TS
+     errors about `@/app/generated/prisma/client` are expected in a
+     fresh worktree — Prisma Client is generated at build time on Vercel;
+     run `npx prisma generate` locally).
+   - Run `npm run lint` and any test script that touches the surface.
+
+6. **Commit + PR**
+   ```
+   git add -A
+   git commit -m "US<N>: <short summary> (closes #<issue>)…"
+   git push -u origin feature/us-<n>-<slug>
+   gh pr create --base main --head feature/us-<n>-<slug> \
+     --title "US<N>: <title> (#<issue>)" \
+     --body <Closes #<issue>, summary, acceptance-criteria checklist>
+   ```
+
+7. **Human review + merge**
+   A human teammate reviews the PR, runs it locally against a seeded DB,
+   and merges via the usual "squash" button. The agent **does not** merge.
+
+## Human responsibilities (what we explicitly did not automate)
+
+- **Merging** PRs into `main` and resolving merge conflicts.
+- **Prisma migrations against the live database**. The agent writes the
+  SQL migration file, but a human runs `npx prisma migrate deploy` in the
+  Supabase environment.
+- **Security-sensitive choices** — auth scopes, rate-limit windows,
+  duplicate-report windows, and any change to `middleware.ts`.
+- **Product calls** — e.g., whether 429 vs 409 is the right status for a
+  24-hour duplicate-report guard, or whether notes should be public.
+- **Fixing the model when it gets something wrong** — for example, the
+  agent initially proposed a looser dedupe window for US17; we tightened
+  it to 24 hours to match the issue.
+
+## System prompt used for generation
+
+Paste this prompt into the agent alongside the issue body. The prompt is
+the same for every story — only the issue body changes.
+
+> You are working in the `GrocerEase` Next.js 16 + Prisma + Supabase
+> repo. Implement the user story quoted below. Follow these constraints:
+>
+> 1. **Match existing patterns.** Authenticated API routes live under
+>    `app/api/...`, return `NextResponse.json(...)`, and gate access with
+>    `requireShopperSession()` / `requireOwnerSession()` from `lib/`.
+>    Client "islands" live under `components/` and are marked
+>    `"use client"`. Server pages live under `app/(public)` or
+>    `app/(dashboard)` and use `auth()` from `@/auth` to resolve role.
+> 2. **Data model.** If the story needs persistence, add a Prisma model
+>    to `prisma/schema.prisma` with `@@map(...)` and `snake_case` column
+>    names, and ship a matching SQL migration under
+>    `prisma/migrations/<timestamp>_<name>/migration.sql`. Reuse enums,
+>    cascade deletes to parents, and add indexes for the expected query
+>    shape.
+> 3. **Respect acceptance criteria verbatim.** Every machine-acceptance
+>    bullet must map to a concrete status code or query in the
+>    implementation. Every human-acceptance bullet must be visible in the
+>    UI you build.
+> 4. **Keep the diff minimal.** Do not refactor unrelated code. Do not
+>    invent feature flags, dashboards, or analytics the story did not ask
+>    for. If the backend already supports what the story wants (e.g.
+>    `/api/stores?category=`), surface it in UI instead of duplicating.
+> 5. **Trust the framework.** Do not add defensive fallbacks for things
+>    Next/Prisma already guarantee. Validate only at the HTTP boundary.
+> 6. **Ship one branch, one PR.** Commit with a message that references
+>    the issue (`Refs #N` / `closes #N`). Open the PR with a body that
+>    mirrors the acceptance-criteria checklist.
+>
+> When uncertain between two reasonable designs, pick the simpler one and
+> note the tradeoff in the PR body. Do not merge — a human reviews.
+
+## Story-level notes
+
+### US15 — Shopper ratings (#119)
+- Asked the agent for: Prisma `StoreRating` + unique(store, shopper) +
+  migration; public GET with average/total/10-per-page notes; POST
+  gated by shopper; DELETE gated by owner-of-rating.
+- What worked: The pattern-matching against `StoreAlertSubscribe` and
+  `require-shopper-session.ts` produced an idiomatic client island on
+  the first try. Server-side aggregate fetch on the profile page avoided
+  layout shift.
+- What needed correction: The first draft returned the Prisma aggregate
+  raw; we wrapped it so the API always returns a rounded `average` and
+  stable shape even when there are zero ratings.
+
+### US16 — Map category filters (#120)
+- Asked the agent for: *only* the UI. Backend already supports
+  `GET /api/stores?category=asian,halal`.
+- What worked: The agent correctly spotted the existing
+  `StoreFilterBar`, reused it, and wired a client `useState<Set<FilterKey>>`
+  through the existing `buildMapStoresApiUrl` helper.
+- What needed correction: Initial pass didn't refetch when filters
+  changed (only on mount). We added `handleFiltersChange` to re-query.
+
+### US17 — Incorrect-info reports (#121)
+- Asked the agent for: Prisma `StoreReport` + enum + migration; shopper
+  POST with 24 h dedupe; owner GET scoped to own store; shopper UI on
+  store page; owner `/dashboard/reports` page and sidebar entry.
+- What worked: The four-type enum + chip UI matched the "lightweight,
+  not punitive" criterion cleanly. The in-place "Thanks — your report
+  was submitted" acknowledgement satisfied human-AC.
+- What needed correction: First draft used 409 for the 24 h duplicate
+  case. We moved to 429 (rate-limit-shaped) with a friendlier message
+  because 409 suggests the same resource already exists, whereas here
+  the shopper is allowed to report again after 24 h.
+
+## PRs delivered under this procedure
+
+- US15 → https://github.com/gsha22/GrocerEase/pull/126 (branch
+  `feature/us-15-store-ratings`)
+- US16 → https://github.com/gsha22/GrocerEase/pull/124 (branch
+  `feature/us-16-map-filters`)
+- US17 → https://github.com/gsha22/GrocerEase/pull/125 (branch
+  `feature/us-17-store-reports`)

--- a/docs/p4-testing-procedure.md
+++ b/docs/p4-testing-procedure.md
@@ -1,0 +1,209 @@
+# P4 Task 4 — Automated Testing Procedure
+
+This document describes the automated test coverage we added for the three
+P4 user stories and the repeatable workflow we use to drive an LLM agent
+to author those tests. Tests live alongside the feature they cover: each
+story's test file is committed to the same branch and PR that introduces
+the feature (so the PR lands the implementation **and** its tests in one
+reviewable unit).
+
+## Tooling
+
+- **Test runner**: [Jest](https://jestjs.io/) (already configured for this
+  repo in [jest.config.mjs](../jest.config.mjs) and
+  [jest.setup.ts](../jest.setup.ts)), with `jest-environment-jsdom`.
+- **Assertions / DOM**: `@testing-library/react` +
+  `@testing-library/jest-dom` + `@testing-library/user-event`.
+- **CI**: GitHub Actions — the `Test` job in
+  [`.github/workflows/ci.yml`](../.github/workflows/ci.yml) runs
+  `npx jest` on every pull request, alongside `Lint`, `Type Check`, and
+  `Build`.
+- **Agent**: Claude Code (Opus 4.7), same configuration as Task 3.
+
+## Repeatable steps
+
+The agent runs these ordered steps for each story. The steps are
+identical across stories; only the component under test differs.
+
+1. **Open a tracking issue.**
+   We opened one GitHub issue per story specifically for the test work,
+   referencing the parent story issue, so reviewers can see the testing
+   sub-task separately from the implementation:
+   - US15 test coverage → issue **#128** (parent #119, PR #126)
+   - US16 test coverage → issue **#129** (parent #120, PR #124)
+   - US17 test coverage → issue **#130** (parent #121, PR #125)
+
+2. **Check out the story's feature branch.**
+   ```
+   git fetch origin feature/us-<n>-<slug>
+   git checkout feature/us-<n>-<slug>
+   ```
+   We do **not** open a new branch — tests land on the same branch that
+   introduced the feature. This keeps the diff reviewable as a single
+   unit and guarantees CI runs both the implementation and its tests on
+   the same PR.
+
+3. **Read the component + surrounding patterns.**
+   - The client component under test (`components/<Name>.tsx` or
+     `app/(public)/<page>/page.tsx`).
+   - Any existing test file that already exercises similar patterns
+     (e.g. `tests/StoreAlertSubscribe.test.tsx` as a reference for
+     mocking `next/link` and viewer-role branches;
+     `tests/MapPage.test.tsx` as a reference for the Map page).
+   - The acceptance criteria of the parent story issue.
+
+4. **Author the test** with the *system prompt* below.
+
+5. **Run the test locally**:
+   ```
+   npx jest tests/<NewFile>.test.tsx
+   ```
+   Only push if every assertion passes locally.
+
+6. **Commit + push to the feature branch** with a message that references
+   the tracking issue (so GitHub cross-links it on the issue timeline):
+   ```
+   git commit -m "test(us<N>): <one-line summary>
+
+   Refs #<tracking-issue>"
+   git push
+   ```
+
+7. **Watch the PR's Test job turn green.**
+   `gh pr checks <PR> --repo gsha22/GrocerEase --watch`. If it fails,
+   switch to the debugging prompt from
+   [p4-code-generation-procedure.md](./p4-code-generation-procedure.md).
+
+## System prompt used for test authoring
+
+Paste this prompt into the agent alongside the component code and the
+parent story's acceptance criteria. The prompt is the same for every
+story — only the component and story number change.
+
+> You are adding Jest tests to the `GrocerEase` Next.js 16 repo. The
+> repo already uses `jest-environment-jsdom` + `@testing-library/react`
+> + `@testing-library/user-event`. Add a new file under
+> `tests/<Component>.test.tsx` that covers the user story quoted below.
+> Follow these constraints:
+>
+> 1. **Test behavior, not implementation.** Assert what a shopper or
+>    owner actually sees in the DOM — role-gated CTAs, chip state,
+>    success and error messages — not internal state. Prefer
+>    `getByRole` with accessible names over test IDs.
+> 2. **Mock at the right seam.** Mock `next/link` as a plain anchor,
+>    `next/dynamic` as a stub component, `navigator.geolocation`, and
+>    `global.fetch`. Do not mock the component under test.
+> 3. **Exercise every branch that is load-bearing for the story.**
+>    Viewer-role gating (null / shopper / owner), success paths,
+>    dedupe/error paths, and any empty-state copy that exists for a
+>    reason. If the story specified a particular HTTP status (e.g. 429
+>    for 24 h dedupe), assert that the friendly error text surfaces.
+> 4. **Keep async assertions correct.** Wrap interactions that trigger
+>    React state updates in `act(...)`, and use
+>    `await screen.findByText(...)` / `waitFor(...)` for anything that
+>    depends on a resolved fetch.
+> 5. **One file per story.** Do not edit unrelated tests. If the story's
+>    feature already has a sibling test file (e.g. `tests/MapPage.test.tsx`),
+>    *add a new file* rather than modifying it — the existing tests
+>    encode the contract from earlier stories.
+> 6. **Head comment = story pointer.** Start the file with a short
+>    docstring that names the story (`Story N — title`), the parent
+>    issue (`#119/#120/#121`), and the tracking issue (`#128/#129/#130`),
+>    so a reviewer can jump from the test to the requirements.
+>
+> When you're done, run `npx jest tests/<NewFile>.test.tsx` locally and
+> paste the output. Do not merge.
+
+## Human responsibilities (what we explicitly did not automate)
+
+- **Judging whether the test coverage matches the story.** The agent
+  generates the tests, but a human verifies that every bullet of the
+  parent story's acceptance criteria is covered by at least one
+  assertion before approving the PR.
+- **Merging** — the agent never merges.
+- **Deciding what *not* to test.** We consciously skipped E2E / Playwright
+  tests for P4 to keep the diff small and the CI runtime under a minute.
+
+## Tests delivered, per story
+
+### US15 — Shopper ratings (#119, PR #126, tracking #128)
+
+File: [tests/StoreRatingsPanel.test.tsx](../tests/StoreRatingsPanel.test.tsx)
+
+Component under test: [components/StoreRatingsPanel.tsx](../components/StoreRatingsPanel.tsx)
+
+| # | Test | What it asserts |
+|---|------|-----------------|
+| 1 | `aggregate header › shows 'no ratings yet' when average is null` | Empty summary renders the "No ratings yet. Be the first!" copy, not a zero-star fake aggregate. |
+| 2 | `aggregate header › shows the average and total when ratings exist` | Populated summary renders `4.3`, `12 ratings`, and the first rating's note body. |
+| 3 | `viewer-role gating › shows a sign-in CTA for logged-out viewers` | `viewerRole={null}` renders a link whose `href` points to `/shopper/login?callbackUrl=…`. |
+| 4 | `viewer-role gating › shows the same CTA for owner viewers` | Owners do not see the rating form — they see the shopper sign-in CTA (owners are not the target audience for US15). |
+| 5 | `shopper submit flow › POSTs the selected score and renders 'Your rating' on success` | Clicking the 4-star button + Submit hits `POST /api/stores/s1/ratings` with body `{ score: 4 }`, then the UI swaps in the "Your rating" card showing `4/5`. |
+| 6 | `shopper submit flow › deletes the shopper's own rating via DELETE` | Given an existing own-rating, clicking "Delete my rating" hits `DELETE /api/stores/s1/ratings/mine-1` and restores the star-picker form. |
+
+### US16 — Map category filters (#120, PR #124, tracking #129)
+
+File: [tests/MapPageCategoryFilters.test.tsx](../tests/MapPageCategoryFilters.test.tsx)
+
+Component under test: [app/(public)/map/page.tsx](../app/(public)/map/page.tsx)
+
+| # | Test | What it asserts |
+|---|------|-----------------|
+| 1 | `buildMapStoresApiUrl › omits the category param when none are selected` | An empty `Set` produces a URL with no `category=` query param. |
+| 2 | `buildMapStoresApiUrl › joins multiple categories with commas` | `new Set(["asian", "halal"])` serializes to `category=asian%2Chalal`. |
+| 3 | `buildMapStoresApiUrl › serializes category only, even without coords` | Null coords + one category → `/api/stores?category=produce` (no `lat`/`lng`/`radius`). |
+| 4 | `MapPage UI › renders a row of category filter chips` | The Asian / Halal / Produce chips are present as buttons after initial load. |
+| 5 | `MapPage UI › shows category tags on each store card under the map` | A fetched store's `categories: ["asian"]` is rendered as a tag pill on its card. |
+| 6 | `MapPage UI › refetches /api/stores with category=asian when the Asian chip is toggled` | After clearing the fetch mock, clicking the Asian chip triggers exactly one `fetch` call whose URL contains `category=asian`. |
+| 7 | `MapPage UI › shows the filtered empty-state copy when no stores match` | After selecting a chip that yields an empty array, the header switches to "No stores match the selected filters." (distinct from the "Finding stores near you…" initial-load copy — this is the contract we regressed and then restored in commit `036b33c`). |
+
+### US17 — Incorrect-info reports (#121, PR #125, tracking #130)
+
+File: [tests/StoreReportButton.test.tsx](../tests/StoreReportButton.test.tsx)
+
+Component under test: [components/StoreReportButton.tsx](../components/StoreReportButton.tsx)
+
+| # | Test | What it asserts |
+|---|------|-----------------|
+| 1 | `viewer-role gating › shows a sign-in CTA for logged-out viewers` | `viewerRole={null}` renders a `/shopper/login?callbackUrl=…` link instead of the report form. |
+| 2 | `viewer-role gating › shows a sign-in CTA for owner viewers` | Owners can't self-report their own store — they see the shopper sign-in CTA. |
+| 3 | `viewer-role gating › renders the report trigger for shoppers` | Shoppers see the "Report incorrect info" button. |
+| 4 | `shopper flow › submits the selected type and shows the acknowledgement` | Clicking the trigger opens the form; clicking the "Hours wrong" chip selects it; clicking "Send report" hits `POST /api/stores/store-42/report` with body `{ type: "incorrect_hours" }`; the "Thanks — your report was submitted." ack appears. |
+| 5 | `shopper flow › surfaces the server error on 429 dedupe` | When the server responds 429 with `{error: "You already reported this store recently…"}`, the friendly message appears in the form and the ack does **not** replace the form (shopper can correct and retry after 24 h). |
+
+## How each test maps to its story's acceptance criteria
+
+- **US15 Human-AC: "I can rate a store 1–5 stars and leave an optional
+  short tip."** → Tests 5 & 6 (submit flow + delete-own-rating).
+- **US15 Human-AC: "I see an average and total rating count on the
+  store page."** → Tests 1 & 2 (aggregate header).
+- **US15 Human-AC: "Only signed-in shoppers can rate."** → Tests 3 & 4
+  (viewer-role gating).
+- **US16 Machine-AC: "/api/stores accepts `category=a,b,c` and returns
+  stores matching *any* of the listed categories."** → Tests 1–3
+  (`buildMapStoresApiUrl` serialization).
+- **US16 Human-AC: "I can filter the map by category with a row of
+  chips."** → Tests 4, 5, 6 (chip rendering, category tags on cards,
+  refetch-on-toggle).
+- **US16 Human-AC: "When my filters don't match anything, I see a copy
+  that says so — not the same empty state as 'still loading'."** →
+  Test 7 (filtered-empty copy).
+- **US17 Machine-AC: "A shopper reporting the same store twice within
+  24 hours gets a 429 with a friendly message."** → Test 5.
+- **US17 Human-AC: "Only signed-in shoppers can report; owners can't
+  self-report their own store."** → Tests 1–3.
+- **US17 Human-AC: "After submitting, I see 'Thanks — your report was
+  submitted.'"** → Test 4.
+
+## Successful CI runs
+
+Each PR's `Test` job (which runs `npx jest` against the full
+`tests/**` suite, including the tests added by this task) passed on
+GitHub Actions:
+
+- US15 (PR #126) → https://github.com/gsha22/GrocerEase/pull/126/checks
+- US16 (PR #124) → https://github.com/gsha22/GrocerEase/pull/124/checks
+- US17 (PR #125) → https://github.com/gsha22/GrocerEase/pull/125/checks
+
+The `Test` job runs alongside `Lint`, `Type Check`, and `Build` on every
+push; all four must pass before a PR is mergeable.


### PR DESCRIPTION
Adds `docs/p4-code-generation-procedure.md` documenting the repeatable LLM-driven workflow we used to implement #119/#120/#121 (P4 task 3 deliverable).

Not tied to any single story; references the three PRs (#124, #125, #126).