### PR TITLE
fix(auth): production NEXTAUTH_URL and password-reset origin

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,7 +5,7 @@
 # • Vercel → Storage → Supabase often sets POSTGRES_PRISMA_URL — GrocerEase uses it if DATABASE_URL is unset.
 DATABASE_URL=postgresql://postgres:[YOUR_PASSWORD]@db.[YOUR_PROJECT_REF].supabase.co:5432/postgres
 
-# Auth.js
+# Auth.js — local dev uses localhost; production uses `.env.production` / Vercel env (see deploy-vercel.md).
 NEXTAUTH_SECRET=your_secret_here
 NEXTAUTH_URL=http://localhost:3000
 

--- a/.env.production
+++ b/.env.production
@@ -1,0 +1,2 @@
+# Loaded when NODE_ENV=production (e.g. Vercel). Canonical site URL for Auth.js callbacks and absolute links.
+NEXTAUTH_URL=https://grocerease.vercel.app

--- a/app/auth/forgot-password/route.ts
+++ b/app/auth/forgot-password/route.ts
@@ -58,7 +58,8 @@ export async function POST(req: NextRequest) {
     });
 
     const base =
-      process.env.NEXTAUTH_URL?.replace(/\/$/, "") ?? "http://localhost:3000";
+      process.env.NEXTAUTH_URL?.replace(/\/$/, "") ??
+      (process.env.VERCEL_URL ? `https://${process.env.VERCEL_URL}` : "http://localhost:3000");
     const resetUrl = `${base}/login/reset?token=${encodeURIComponent(tokenRaw)}`;
 
     const emailResult = await sendPasswordResetEmail({


### PR DESCRIPTION
## Summary

Sets **`NEXTAUTH_URL`** for production via committed **`.env.production`** (`https://grocerease.vercel.app`), matching the live Vercel deployment.

Also updates the forgot-password route to use the same **`VERCEL_URL`** fallback as `app/layout.tsx` when `NEXTAUTH_URL` is unset, so reset links are not built with `localhost`.

`.env.example` notes that local dev keeps localhost and production uses `.env.production` / Vercel settings (see `docs/deploy-vercel.md`).

## Note for maintainers

If **Vercel → Environment Variables** still has `NEXTAUTH_URL=http://localhost:3000`, remove or update that value—dashboard env vars can override file-based defaults.

Made with [Cursor](https://cursor.com)