### PR TITLE
fix(auth): post-login redirects (owner /owner-dashboard, shopper home)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,7 +5,7 @@
 # • Vercel → Storage → Supabase often sets POSTGRES_PRISMA_URL — GrocerEase uses it if DATABASE_URL is unset.
 DATABASE_URL=postgresql://postgres:[YOUR_PASSWORD]@db.[YOUR_PROJECT_REF].supabase.co:5432/postgres
 
-# Auth.js
+# Auth.js — local dev uses localhost; production uses `.env.production` / Vercel env (see deploy-vercel.md).
 NEXTAUTH_SECRET=your_secret_here
 NEXTAUTH_URL=http://localhost:3000
 

--- a/.env.production
+++ b/.env.production
@@ -1,0 +1,2 @@
+# Loaded when NODE_ENV=production (e.g. Vercel). Canonical site URL for Auth.js callbacks and absolute links.
+NEXTAUTH_URL=https://grocerease.vercel.app

--- a/app/(public)/login/LoginForm.tsx
+++ b/app/(public)/login/LoginForm.tsx
@@ -8,20 +8,32 @@ import {
   safeCallbackPath,
 } from "@/lib/safe-callback-path";
 
+type LoginSuccessJson = {
+  ok?: boolean;
+  error?: string;
+  redirectUrl?: string;
+  role?: string;
+};
+
 export default function LoginForm() {
   const router = useRouter();
   const searchParams = useSearchParams();
-  const callbackUrl = safeCallbackPath(searchParams.get("callbackUrl"));
+  const callbackUrl = safeCallbackPath(
+    searchParams.get("callbackUrl"),
+    "/owner-dashboard",
+  );
 
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [error, setError] = useState<string | null>(null);
   const [pending, setPending] = useState(false);
+  const [redirecting, setRedirecting] = useState(false);
 
   async function onSubmit(e: React.FormEvent) {
     e.preventDefault();
     setError(null);
     setPending(true);
+    let didNavigate = false;
     try {
       const res = await fetch("/auth/login", {
         method: "POST",
@@ -33,32 +45,49 @@ export default function LoginForm() {
           callbackUrl,
         }),
       });
-      const data = await res.json().catch(() => ({}));
+      const data = (await res.json().catch(() => ({}))) as LoginSuccessJson;
 
       if (!res.ok) {
         setError(
           typeof data.error === "string"
             ? data.error
-            : "Could not sign in. Try again."
+            : "Could not sign in. Try again.",
         );
         return;
       }
 
+      if (!data.ok) {
+        setError("Unexpected response from server.");
+        return;
+      }
+
+      let dest: string | null = null;
       if (
-        data.ok &&
         typeof data.redirectUrl === "string" &&
         isSafeRelativeAppPath(data.redirectUrl)
       ) {
-        router.push(data.redirectUrl);
+        dest = data.redirectUrl;
+      } else if (data.role === "owner") {
+        dest = "/owner-dashboard";
+      }
+
+      if (dest) {
+        setRedirecting(true);
+        didNavigate = true;
+        router.push(dest);
         router.refresh();
         return;
       }
 
       setError("Unexpected response from server.");
     } finally {
-      setPending(false);
+      if (!didNavigate) {
+        setPending(false);
+      }
     }
   }
+
+  const busy = pending || redirecting;
 
   return (
     <form onSubmit={onSubmit} className="space-y-4">
@@ -69,6 +98,15 @@ export default function LoginForm() {
         >
           {error}
         </div>
+      )}
+
+      {redirecting && !error && (
+        <p
+          className="rounded-md border border-emerald-100 bg-emerald-50/80 px-3 py-2 text-[13px] text-emerald-900"
+          aria-live="polite"
+        >
+          Redirecting…
+        </p>
       )}
 
       <div>
@@ -86,7 +124,8 @@ export default function LoginForm() {
           value={email}
           onChange={(e) => setEmail(e.target.value)}
           placeholder="you@example.com"
-          className="w-full px-3.5 py-2.5 rounded-md border-[1.5px] border-gray-200 text-[15px] text-gray-800 bg-white outline-none focus:border-green-400 transition-colors"
+          disabled={busy}
+          className="w-full px-3.5 py-2.5 rounded-md border-[1.5px] border-gray-200 text-[15px] text-gray-800 bg-white outline-none focus:border-green-400 transition-colors disabled:opacity-60"
         />
       </div>
 
@@ -105,7 +144,8 @@ export default function LoginForm() {
           value={password}
           onChange={(e) => setPassword(e.target.value)}
           placeholder="Your password"
-          className="w-full px-3.5 py-2.5 rounded-md border-[1.5px] border-gray-200 text-[15px] text-gray-800 bg-white outline-none focus:border-green-400 transition-colors"
+          disabled={busy}
+          className="w-full px-3.5 py-2.5 rounded-md border-[1.5px] border-gray-200 text-[15px] text-gray-800 bg-white outline-none focus:border-green-400 transition-colors disabled:opacity-60"
         />
         <div className="mt-2">
           <Link
@@ -119,10 +159,14 @@ export default function LoginForm() {
 
       <button
         type="submit"
-        disabled={pending}
+        disabled={busy}
         className="w-full py-3 rounded-md text-[15px] font-semibold text-white bg-green-600 hover:bg-green-800 transition-colors mt-1 disabled:opacity-60"
       >
-        {pending ? "Signing in…" : "Sign in"}
+        {redirecting
+          ? "Redirecting…"
+          : pending
+            ? "Signing in…"
+            : "Sign in"}
       </button>
     </form>
   );

--- a/app/(public)/login/page.tsx
+++ b/app/(public)/login/page.tsx
@@ -7,7 +7,7 @@ import LoginForm from "./LoginForm";
 export default async function LoginPage() {
   const session = await auth();
   if (session?.user) {
-    redirect(session.role === "shopper" ? "/shopper/account" : "/dashboard");
+    redirect(session.role === "shopper" ? "/" : "/owner-dashboard");
   }
 
   return (

--- a/app/(public)/owner-dashboard/page.tsx
+++ b/app/(public)/owner-dashboard/page.tsx
@@ -1,0 +1,6 @@
+import { redirect } from "next/navigation";
+
+/** Alias URL for the store-owner portal (`/dashboard`). */
+export default function OwnerDashboardAliasPage() {
+  redirect("/dashboard");
+}

--- a/app/(public)/shopper/login/ShopperLoginForm.tsx
+++ b/app/(public)/shopper/login/ShopperLoginForm.tsx
@@ -8,23 +8,35 @@ import {
   safeCallbackPath,
 } from "@/lib/safe-callback-path";
 
+/** Default after shopper login: home page with nearby stores (`/`). `/stores` also resolves to the same view. */
+const SHOPPER_HOME = "/";
+
+type LoginSuccessJson = {
+  ok?: boolean;
+  error?: string;
+  redirectUrl?: string;
+  role?: string;
+};
+
 export default function ShopperLoginForm() {
   const router = useRouter();
   const searchParams = useSearchParams();
   const callbackUrl = safeCallbackPath(
     searchParams.get("callbackUrl"),
-    "/shopper/account"
+    SHOPPER_HOME,
   );
 
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [error, setError] = useState<string | null>(null);
   const [pending, setPending] = useState(false);
+  const [redirecting, setRedirecting] = useState(false);
 
   async function onSubmit(e: React.FormEvent) {
     e.preventDefault();
     setError(null);
     setPending(true);
+    let didNavigate = false;
     try {
       const res = await fetch("/auth/shopper/login", {
         method: "POST",
@@ -36,32 +48,49 @@ export default function ShopperLoginForm() {
           callbackUrl,
         }),
       });
-      const data = await res.json().catch(() => ({}));
+      const data = (await res.json().catch(() => ({}))) as LoginSuccessJson;
 
       if (!res.ok) {
         setError(
           typeof data.error === "string"
             ? data.error
-            : "Could not sign in. Try again."
+            : "Could not sign in. Try again.",
         );
         return;
       }
 
+      if (!data.ok) {
+        setError("Unexpected response from server.");
+        return;
+      }
+
+      let dest: string | null = null;
       if (
-        data.ok &&
         typeof data.redirectUrl === "string" &&
         isSafeRelativeAppPath(data.redirectUrl)
       ) {
-        router.push(data.redirectUrl);
+        dest = data.redirectUrl;
+      } else if (data.role === "shopper") {
+        dest = SHOPPER_HOME;
+      }
+
+      if (dest) {
+        setRedirecting(true);
+        didNavigate = true;
+        router.push(dest);
         router.refresh();
         return;
       }
 
       setError("Unexpected response from server.");
     } finally {
-      setPending(false);
+      if (!didNavigate) {
+        setPending(false);
+      }
     }
   }
+
+  const busy = pending || redirecting;
 
   return (
     <form onSubmit={onSubmit} className="space-y-4">
@@ -72,6 +101,15 @@ export default function ShopperLoginForm() {
         >
           {error}
         </div>
+      )}
+
+      {redirecting && !error && (
+        <p
+          className="rounded-md border border-emerald-100 bg-emerald-50/80 px-3 py-2 text-[13px] text-emerald-900"
+          aria-live="polite"
+        >
+          Redirecting…
+        </p>
       )}
 
       <div>
@@ -89,7 +127,8 @@ export default function ShopperLoginForm() {
           value={email}
           onChange={(e) => setEmail(e.target.value)}
           placeholder="you@example.com"
-          className="w-full px-3.5 py-2.5 rounded-md border-[1.5px] border-gray-200 text-[15px] text-gray-800 bg-white outline-none focus:border-green-400 transition-colors"
+          disabled={busy}
+          className="w-full px-3.5 py-2.5 rounded-md border-[1.5px] border-gray-200 text-[15px] text-gray-800 bg-white outline-none focus:border-green-400 transition-colors disabled:opacity-60"
         />
       </div>
 
@@ -108,16 +147,21 @@ export default function ShopperLoginForm() {
           value={password}
           onChange={(e) => setPassword(e.target.value)}
           placeholder="Your password"
-          className="w-full px-3.5 py-2.5 rounded-md border-[1.5px] border-gray-200 text-[15px] text-gray-800 bg-white outline-none focus:border-green-400 transition-colors"
+          disabled={busy}
+          className="w-full px-3.5 py-2.5 rounded-md border-[1.5px] border-gray-200 text-[15px] text-gray-800 bg-white outline-none focus:border-green-400 transition-colors disabled:opacity-60"
         />
       </div>
 
       <button
         type="submit"
-        disabled={pending}
+        disabled={busy}
         className="w-full py-3 rounded-md text-[15px] font-semibold text-white bg-green-600 hover:bg-green-800 transition-colors mt-1 disabled:opacity-60"
       >
-        {pending ? "Signing in…" : "Sign in"}
+        {redirecting
+          ? "Redirecting…"
+          : pending
+            ? "Signing in…"
+            : "Sign in"}
       </button>
 
       <p className="text-center text-[13px] text-gray-500">

--- a/app/(public)/shopper/login/page.tsx
+++ b/app/(public)/shopper/login/page.tsx
@@ -7,7 +7,7 @@ import ShopperLoginForm from "./ShopperLoginForm";
 export default async function ShopperLoginPage() {
   const session = await auth();
   if (session?.user) {
-    redirect(session.role === "shopper" ? "/shopper/account" : "/dashboard");
+    redirect(session.role === "shopper" ? "/" : "/owner-dashboard");
   }
 
   return (

--- a/app/(public)/shopper/signup/ShopperSignupForm.tsx
+++ b/app/(public)/shopper/signup/ShopperSignupForm.tsx
@@ -19,10 +19,7 @@ interface SignupApiResponse {
 export default function ShopperSignupForm() {
   const router = useRouter();
   const searchParams = useSearchParams();
-  const callbackUrl = safeCallbackPath(
-    searchParams.get("callbackUrl"),
-    "/shopper/account"
-  );
+  const callbackUrl = safeCallbackPath(searchParams.get("callbackUrl"), "/");
 
   const [name, setName] = useState("");
   const [email, setEmail] = useState("");
@@ -89,9 +86,7 @@ export default function ShopperSignupForm() {
       if (res.status === 201 && data.ok) {
         const raw = data.redirectUrl;
         const url =
-          typeof raw === "string" && isSafeRelativeAppPath(raw)
-            ? raw
-            : "/shopper/account";
+          typeof raw === "string" && isSafeRelativeAppPath(raw) ? raw : "/";
         router.push(url);
         router.refresh();
         return;

--- a/app/(public)/shopper/signup/page.tsx
+++ b/app/(public)/shopper/signup/page.tsx
@@ -7,7 +7,7 @@ import ShopperSignupForm from "./ShopperSignupForm";
 export default async function ShopperSignupPage() {
   const session = await auth();
   if (session?.user) {
-    redirect(session.role === "shopper" ? "/shopper/account" : "/dashboard");
+    redirect(session.role === "shopper" ? "/" : "/owner-dashboard");
   }
 
   return (

--- a/app/(public)/sign-in/page.tsx
+++ b/app/(public)/sign-in/page.tsx
@@ -24,8 +24,10 @@ export default async function SignInPage({
   const next = safeNextPath(sp.next);
   const shopperQs = next
     ? `?callbackUrl=${encodeURIComponent(next)}`
-    : "?callbackUrl=%2Fshopper%2Faccount";
-  const ownerQs = next ? `?callbackUrl=${encodeURIComponent(next)}` : "";
+    : "?callbackUrl=%2F";
+  const ownerQs = next
+    ? `?callbackUrl=${encodeURIComponent(next)}`
+    : "?callbackUrl=%2Fowner-dashboard";
 
   return (
     <div className="mx-auto flex min-h-[calc(100dvh-8rem)] max-w-3xl flex-col justify-center px-4 py-12 sm:px-6">

--- a/app/(public)/signup/SignupForm.tsx
+++ b/app/(public)/signup/SignupForm.tsx
@@ -19,7 +19,10 @@ interface SignupApiResponse {
 export default function SignupForm() {
   const router = useRouter();
   const searchParams = useSearchParams();
-  const callbackUrl = safeCallbackPath(searchParams.get("callbackUrl"));
+  const callbackUrl = safeCallbackPath(
+    searchParams.get("callbackUrl"),
+    "/owner-dashboard",
+  );
 
   const [name, setName] = useState("");
   const [email, setEmail] = useState("");

--- a/app/(public)/signup/page.tsx
+++ b/app/(public)/signup/page.tsx
@@ -7,7 +7,7 @@ import SignupForm from "./SignupForm";
 export default async function SignupPage() {
   const session = await auth();
   if (session?.user) {
-    redirect(session.role === "shopper" ? "/shopper/account" : "/dashboard");
+    redirect(session.role === "shopper" ? "/" : "/owner-dashboard");
   }
 
   return (

--- a/app/(public)/stores/page.tsx
+++ b/app/(public)/stores/page.tsx
@@ -1,0 +1,6 @@
+import { redirect } from "next/navigation";
+
+/** Browse all stores — same experience as the home page (`/`). */
+export default function StoresIndexPage() {
+  redirect("/");
+}

--- a/app/auth/forgot-password/route.ts
+++ b/app/auth/forgot-password/route.ts
@@ -58,7 +58,8 @@ export async function POST(req: NextRequest) {
     });
 
     const base =
-      process.env.NEXTAUTH_URL?.replace(/\/$/, "") ?? "http://localhost:3000";
+      process.env.NEXTAUTH_URL?.replace(/\/$/, "") ??
+      (process.env.VERCEL_URL ? `https://${process.env.VERCEL_URL}` : "http://localhost:3000");
     const resetUrl = `${base}/login/reset?token=${encodeURIComponent(tokenRaw)}`;
 
     const emailResult = await sendPasswordResetEmail({

--- a/app/auth/login/route.ts
+++ b/app/auth/login/route.ts
@@ -30,7 +30,7 @@ export async function POST(req: NextRequest) {
   const rawEmail = typeof body.email === "string" ? body.email : "";
   const email = rawEmail.trim().toLowerCase();
   const password = typeof body.password === "string" ? body.password : "";
-  const callbackUrl = safeCallbackPath(body.callbackUrl);
+  const callbackUrl = safeCallbackPath(body.callbackUrl, "/owner-dashboard");
 
   if (!email || !password) {
     return NextResponse.json(
@@ -39,7 +39,14 @@ export async function POST(req: NextRequest) {
     );
   }
 
-  const response = await runCredentialsSignIn(req, email, password, callbackUrl);
+  const response = await runCredentialsSignIn(
+    req,
+    email,
+    password,
+    callbackUrl,
+    "owner",
+    "/owner-dashboard",
+  );
 
   await writeAuthAuditLog({
     event: "login_attempt",

--- a/app/auth/shopper/login/route.ts
+++ b/app/auth/shopper/login/route.ts
@@ -21,10 +21,7 @@ export async function POST(req: NextRequest) {
   const rawEmail = typeof body.email === "string" ? body.email : "";
   const email = rawEmail.trim().toLowerCase();
   const password = typeof body.password === "string" ? body.password : "";
-  const callbackUrl = safeCallbackPath(
-    body.callbackUrl,
-    "/shopper/account"
-  );
+  const callbackUrl = safeCallbackPath(body.callbackUrl, "/");
 
   if (!email || !password) {
     return NextResponse.json(
@@ -33,12 +30,5 @@ export async function POST(req: NextRequest) {
     );
   }
 
-  return runCredentialsSignIn(
-    req,
-    email,
-    password,
-    callbackUrl,
-    "shopper",
-    "/shopper/account"
-  );
+  return runCredentialsSignIn(req, email, password, callbackUrl, "shopper", "/");
 }

--- a/app/auth/shopper/signup/route.ts
+++ b/app/auth/shopper/signup/route.ts
@@ -23,7 +23,7 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
   }
 
-  const validated = validateSignupInput(body, "/shopper/account");
+  const validated = validateSignupInput(body, "/");
   if (!validated.ok) {
     return NextResponse.json(
       { error: "Validation failed", fieldErrors: validated.errors },
@@ -101,7 +101,7 @@ export async function POST(req: NextRequest) {
     password,
     callbackUrl,
     "shopper",
-    "/shopper/account"
+    "/",
   );
   const setCookies = signInRes.headers.getSetCookie?.() ?? [];
   const signInJson = (await signInRes.json().catch(() => null)) as {

--- a/app/auth/signup-shopper/route.ts
+++ b/app/auth/signup-shopper/route.ts
@@ -79,7 +79,14 @@ export async function POST(req: NextRequest) {
     );
   }
 
-  const signInRes = await runCredentialsSignIn(req, email, password, callbackUrl);
+  const signInRes = await runCredentialsSignIn(
+    req,
+    email,
+    password,
+    callbackUrl,
+    "shopper",
+    "/",
+  );
   const setCookies = signInRes.headers.getSetCookie?.() ?? [];
   const signInJson = (await signInRes.json().catch(() => null)) as {
     ok?: boolean;

--- a/app/auth/signup/route.ts
+++ b/app/auth/signup/route.ts
@@ -89,6 +89,8 @@ export async function POST(req: NextRequest) {
     email,
     password,
     callbackUrl,
+    "owner",
+    "/owner-dashboard",
   );
   const setCookies = signInRes.headers.getSetCookie?.() ?? [];
   const signInJson = (await signInRes.json().catch(() => null)) as {

--- a/auth.ts
+++ b/auth.ts
@@ -1,7 +1,11 @@
 import NextAuth from "next-auth";
 import { authConfig } from "./auth.config";
+import { getAuthSecret } from "@/lib/auth-secret";
 
-export const { handlers, auth, signIn, signOut } = NextAuth(authConfig);
+export const { handlers, auth, signIn, signOut } = NextAuth({
+  ...authConfig,
+  secret: getAuthSecret(),
+});
 
 /** Shared config (mutated by NextAuth with env defaults). Re-exported for internal Auth() calls. */
 export { authConfig };

--- a/lib/auth-secret.ts
+++ b/lib/auth-secret.ts
@@ -1,0 +1,14 @@
+/**
+ * Auth.js requires a secret for JWT/session cookies. Set `AUTH_SECRET` or
+ * `NEXTAUTH_SECRET` in `.env`. In development, a placeholder is used when
+ * neither is set so local `npm run dev` works without MissingSecret errors.
+ */
+export function getAuthSecret(): string | undefined {
+  return (
+    process.env.AUTH_SECRET ??
+    process.env.NEXTAUTH_SECRET ??
+    (process.env.NODE_ENV === "development"
+      ? "dev-placeholder-secret-set-NEXTAUTH_SECRET-in-dotenv"
+      : undefined)
+  );
+}

--- a/lib/credentials-sign-in-response.ts
+++ b/lib/credentials-sign-in-response.ts
@@ -1,6 +1,8 @@
 import { Auth, skipCSRFCheck } from "@auth/core";
 import { NextRequest, NextResponse } from "next/server";
 import { authConfig } from "@/auth";
+import { getAuthSecret } from "@/lib/auth-secret";
+import { safeCallbackPath } from "@/lib/safe-callback-path";
 
 /**
  * Turns Auth.js Location into a same-origin path safe for client router.push
@@ -39,7 +41,7 @@ export function buildCredentialsAuthRequest(
   email: string,
   password: string,
   callbackUrl: string,
-  accountType: CredentialsAccountType = "owner"
+  accountType: CredentialsAccountType = "owner",
 ) {
   const origin = req.nextUrl.origin;
   const url = new URL(`${origin}/api/auth/callback/credentials`);
@@ -53,12 +55,15 @@ export function buildCredentialsAuthRequest(
 }
 
 /**
- * Maps Auth.js credentials callback Response to a JSON API response + session cookies.
+ * Maps Auth.js credentials callback to JSON + Set-Cookie.
+ * Uses the sanitized redirect path passed to Auth.js so the client always gets
+ * a stable `redirectUrl` (the Location header can differ by version).
  */
 export function nextResponseFromCredentialsAuth(
   req: NextRequest,
   authRes: Response,
-  fallbackPath: string = "/dashboard",
+  successRedirectPath: string,
+  role: "owner" | "shopper",
 ): NextResponse {
   const location = authRes.headers.get("Location") ?? "";
 
@@ -68,18 +73,15 @@ export function nextResponseFromCredentialsAuth(
   ) {
     return NextResponse.json(
       { error: "Invalid email or password." },
-      { status: 401 }
+      { status: 401 },
     );
   }
 
   if (authRes.status === 302 || authRes.status === 303) {
     const res = NextResponse.json({
       ok: true,
-      redirectUrl: safeRedirectPathForClient(
-        location,
-        req.nextUrl.origin,
-        fallbackPath
-      ),
+      role,
+      redirectUrl: successRedirectPath,
     });
     const rawCookies = authRes.headers.getSetCookie?.() ?? [];
     for (const cookie of rawCookies) {
@@ -100,18 +102,21 @@ export async function runCredentialsSignIn(
   password: string,
   callbackUrl: string,
   accountType: CredentialsAccountType = "owner",
-  fallbackPath: string = "/dashboard"
+  fallbackPath: string = "/dashboard",
 ): Promise<NextResponse> {
+  const resolvedRedirect = safeCallbackPath(callbackUrl, fallbackPath);
   const authRequest = buildCredentialsAuthRequest(
     req,
     email,
     password,
-    callbackUrl,
-    accountType
+    resolvedRedirect,
+    accountType,
   );
   const authRes = await Auth(authRequest, {
     ...authConfig,
+    secret: getAuthSecret(),
     skipCSRFCheck,
   });
-  return nextResponseFromCredentialsAuth(req, authRes, fallbackPath);
+  const role = accountType === "shopper" ? "shopper" : "owner";
+  return nextResponseFromCredentialsAuth(req, authRes, resolvedRedirect, role);
 }

--- a/lib/validate-owner-signup.ts
+++ b/lib/validate-owner-signup.ts
@@ -4,7 +4,7 @@ export type OwnerSignupInput = {
   email: string;
   password: string;
   name: string;
-  /** Same-origin path only; defaults to /dashboard */
+  /** Same-origin path only; defaults to /owner-dashboard */
   callbackUrl: string;
 };
 
@@ -17,7 +17,7 @@ const EMAIL_RE =
 
 export function validateSignupInput(
   body: unknown,
-  defaultCallbackPath: string = "/dashboard",
+  defaultCallbackPath: string = "/owner-dashboard",
 ): SignupValidationResult {
   if (!body || typeof body !== "object") {
     return { ok: false, errors: { form: "Invalid JSON body." } };

--- a/middleware.ts
+++ b/middleware.ts
@@ -2,6 +2,7 @@ import { NextResponse } from "next/server";
 import type { NextRequest } from "next/server";
 import type { JWT } from "next-auth/jwt";
 import { getToken } from "next-auth/jwt";
+import { getAuthSecret } from "@/lib/auth-secret";
 
 function isShopperToken(token: Awaited<ReturnType<typeof getToken>>) {
   if (!token || typeof token === "string") return false;
@@ -10,7 +11,7 @@ function isShopperToken(token: Awaited<ReturnType<typeof getToken>>) {
 }
 
 export async function middleware(req: NextRequest) {
-  const token = await getToken({ req, secret: process.env.NEXTAUTH_SECRET });
+  const token = await getToken({ req, secret: getAuthSecret() });
   const path = req.nextUrl.pathname;
 
   if (path.startsWith("/dashboard") || path.startsWith("/vendor")) {

--- a/scripts/alerts-machine-tests.ts
+++ b/scripts/alerts-machine-tests.ts
@@ -22,7 +22,7 @@ async function loginShopper() {
     body: JSON.stringify({
       email: SHOPPER_EMAIL,
       password: SHOPPER_PASSWORD,
-      callbackUrl: "/shopper/account",
+      callbackUrl: "/",
     }),
   });
   const setCookies = res.headers.getSetCookie?.() ?? [];

--- a/scripts/auth-machine-tests.ts
+++ b/scripts/auth-machine-tests.ts
@@ -64,7 +64,7 @@ async function login(email: string, password: string) {
   const { res, json, setCookies } = await postJson("/auth/login", {
     email,
     password,
-    callbackUrl: "/dashboard",
+    callbackUrl: "/owner-dashboard",
   });
   return {
     res,
@@ -126,6 +126,16 @@ async function main() {
       "valid login should return ok: true"
     );
     assert.ok(cookieHeader.length > 0, "valid login should Set-Cookie");
+    assert.equal(
+      (json as { redirectUrl?: string }).redirectUrl,
+      "/owner-dashboard",
+      "login response should include redirectUrl",
+    );
+    assert.equal(
+      (json as { role?: string }).role,
+      "owner",
+      "login response should include role owner",
+    );
     const body = JSON.stringify(json);
     assert.ok(
       !body.toLowerCase().includes("password") &&
@@ -200,8 +210,8 @@ async function main() {
     );
     const loc = res.headers.get("location") ?? "";
     assert.ok(
-      loc.includes("/dashboard"),
-      `expected /login to redirect to dashboard, got: ${loc}`
+      loc.includes("/owner-dashboard") || loc.includes("/dashboard"),
+      `expected /login to redirect toward owner dashboard, got: ${loc}`
     );
   }
 

--- a/scripts/shopper-auth-machine-tests.ts
+++ b/scripts/shopper-auth-machine-tests.ts
@@ -68,7 +68,7 @@ async function shopperLogin(email: string, password: string) {
   return postJson("/auth/shopper/login", {
     email,
     password,
-    callbackUrl: "/shopper/account",
+    callbackUrl: "/",
   });
 }
 
@@ -249,7 +249,7 @@ async function main() {
       email: newEmail,
       password: newPassword,
       confirmPassword: newPassword,
-      callbackUrl: "/shopper/account",
+      callbackUrl: "/",
     });
     assert.equal(res.status, 201, "signup should return 201");
     assert.ok(
@@ -297,7 +297,7 @@ async function main() {
       email: newEmail,
       password: newPassword,
       confirmPassword: newPassword,
-      callbackUrl: "/shopper/account",
+      callbackUrl: "/",
     });
     assert.equal(res.status, 409, "duplicate shopper email should be 409");
     assertNoPasswordLeak(json, newPassword);
@@ -310,7 +310,7 @@ async function main() {
       email: OWNER_EMAIL,
       password: newPassword,
       confirmPassword: newPassword,
-      callbackUrl: "/shopper/account",
+      callbackUrl: "/",
     });
     assert.equal(res.status, 409, "shopper signup with owner email should be 409");
     assertNoPasswordLeak(json, newPassword);


### PR DESCRIPTION
## Summary

Fixes users staying on the login page after successful sign-in by returning a **stable `redirectUrl` and `role`** from the credentials auth JSON (aligned with the sanitized callback sent to Auth.js).

## Changes

- **`lib/auth-secret.ts`** — shared `getAuthSecret()` for NextAuth, internal `Auth()` calls, and middleware JWT verification; dev-only placeholder when `AUTH_SECRET` / `NEXTAUTH_SECRET` are unset.
- **`lib/credentials-sign-in-response.ts`** — success response: `{ ok, role, redirectUrl }` from the resolved callback path.
- **Owners** — default post-login **`/owner-dashboard`** → **`app/(public)/owner-dashboard/page.tsx`** redirects to **`/dashboard`**.
- **Shoppers** — default **`/`** (store discovery). **`/stores`** added as redirect to **`/`**.
- **Login forms** — `useRouter` from `next/navigation`, role fallbacks, **Redirecting…** state.
- Sign-in hub, signup routes, and machine scripts updated for the same defaults.

## Verification

- `npm run build` and `npm run test:jest` pass locally.

Production should still set **`AUTH_SECRET` or `NEXTAUTH_SECRET`** in the environment.

Made with [Cursor](https://cursor.com)