### PR TITLE
fix(auth): use AUTH_URL for credentials callback origin

### DIFF
--- a/lib/credentials-sign-in-response.ts
+++ b/lib/credentials-sign-in-response.ts
@@ -43,7 +43,9 @@ export function buildCredentialsAuthRequest(
   callbackUrl: string,
   accountType: CredentialsAccountType = "owner",
 ) {
-  const origin = req.nextUrl.origin;
+  const origin =
+    (process.env.AUTH_URL ?? process.env.NEXTAUTH_URL)?.replace(/\/$/, "") ??
+    req.nextUrl.origin;
   const url = new URL(`${origin}/api/auth/callback/credentials`);
   url.searchParams.set("callbackUrl", callbackUrl);
 


### PR DESCRIPTION
## Summary
- Fixes `UnknownAction: Cannot parse action at /api/auth/callback/credentials` error in production
- `buildCredentialsAuthRequest` was using `req.nextUrl.origin`, which on Vercel resolves to a per-deployment URL (e.g. `grocerease-mxakxja8i-....vercel.app`) instead of the stable `AUTH_URL`
- NextAuth rejects the callback because the URL doesn't match `AUTH_URL`, causing the `UnknownAction` error
- Fix: prefer `AUTH_URL` (falling back to `NEXTAUTH_URL` for v4 `.env` compat) over the request origin

## Test plan
- [ ] Log in as store owner on production — should succeed without `UnknownAction` error
- [ ] Log in as shopper on production — should succeed
- [ ] Local dev login still works (falls back to `req.nextUrl.origin` when neither env var is set)

🤖 Generated with [Claude Code](https://claude.com/claude-code)