### PR TITLE
fix(auth): set basePath when calling Auth() directly

### DIFF
--- a/lib/credentials-sign-in-response.ts
+++ b/lib/credentials-sign-in-response.ts
@@ -117,6 +117,7 @@ export async function runCredentialsSignIn(
   const authRes = await Auth(authRequest, {
     ...authConfig,
     secret: getAuthSecret(),
+    basePath: "/api/auth",
     skipCSRFCheck,
   });
   const role = accountType === "shopper" ? "shopper" : "owner";


### PR DESCRIPTION
## Summary
- Fixes persistent `UnknownAction: Cannot parse action at /api/auth/callback/credentials` error in production
- Root cause: `@auth/core` defaults `basePath` to `"/auth"`, but GrocerEase routes use `"/api/auth"`. When `Auth()` is called directly in `runCredentialsSignIn`, it couldn't match the URL path to a known action
- Fix: pass `basePath: "/api/auth"` explicitly to `Auth()` to match the app's route structure

## Test plan
- [x] `npm run test:shopper-auth` — all tests pass locally
- [x] `npm run test:auth` — login flow passes (session cookie returned correctly)
- [ ] Verify owner and shopper login succeed in production after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)