### PR TITLE
fix(middleware): use authjs.session-token cookie name for NextAuth v5

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -4,22 +4,27 @@ import type { JWT } from "next-auth/jwt";
 import { getToken } from "next-auth/jwt";
 import { getAuthSecret } from "@/lib/auth-secret";
 
-// NextAuth v5 renamed the session cookie from "next-auth.session-token" to "authjs.session-token".
-// In production (HTTPS), @auth/core prefixes cookies with "__Secure-".
-const useSecureCookies = (process.env.AUTH_URL ?? process.env.NEXTAUTH_URL ?? "").startsWith("https://");
-const SESSION_COOKIE = `${useSecureCookies ? "__Secure-" : ""}authjs.session-token`;
-
 function isShopperToken(token: Awaited<ReturnType<typeof getToken>>) {
   if (!token || typeof token === "string") return false;
   const t = token as JWT;
   return t.role === "shopper" || Boolean(t.shopperId);
 }
 
+// Mirror @auth/core's useSecureCookies logic: check the actual request protocol.
+// x-forwarded-proto is set by Vercel/proxies; fall back to the request URL protocol.
+function getSessionCookieName(req: NextRequest): string {
+  const proto =
+    req.headers.get("x-forwarded-proto") ??
+    req.nextUrl.protocol.replace(":", "");
+  const secure = proto === "https";
+  return `${secure ? "__Secure-" : ""}authjs.session-token`;
+}
+
 export async function middleware(req: NextRequest) {
   const token = await getToken({
     req,
     secret: getAuthSecret(),
-    cookieName: SESSION_COOKIE,
+    cookieName: getSessionCookieName(req),
   });
   const path = req.nextUrl.pathname;
 

--- a/middleware.ts
+++ b/middleware.ts
@@ -4,6 +4,9 @@ import type { JWT } from "next-auth/jwt";
 import { getToken } from "next-auth/jwt";
 import { getAuthSecret } from "@/lib/auth-secret";
 
+// NextAuth v5 renamed the session cookie from "next-auth.session-token" to "authjs.session-token"
+const SESSION_COOKIE = "authjs.session-token";
+
 function isShopperToken(token: Awaited<ReturnType<typeof getToken>>) {
   if (!token || typeof token === "string") return false;
   const t = token as JWT;
@@ -11,7 +14,11 @@ function isShopperToken(token: Awaited<ReturnType<typeof getToken>>) {
 }
 
 export async function middleware(req: NextRequest) {
-  const token = await getToken({ req, secret: getAuthSecret() });
+  const token = await getToken({
+    req,
+    secret: getAuthSecret(),
+    cookieName: SESSION_COOKIE,
+  });
   const path = req.nextUrl.pathname;
 
   if (path.startsWith("/dashboard") || path.startsWith("/vendor")) {

--- a/middleware.ts
+++ b/middleware.ts
@@ -13,9 +13,10 @@ function isShopperToken(token: Awaited<ReturnType<typeof getToken>>) {
 // Mirror @auth/core's useSecureCookies logic: check the actual request protocol.
 // x-forwarded-proto is set by Vercel/proxies; fall back to the request URL protocol.
 function getSessionCookieName(req: NextRequest): string {
-  const proto =
-    req.headers.get("x-forwarded-proto") ??
-    req.nextUrl.protocol.replace(":", "");
+  const proto = (
+    req.headers.get("x-forwarded-proto")?.split(",")[0].trim() ??
+    req.nextUrl.protocol.replace(":", "")
+  );
   const secure = proto === "https";
   return `${secure ? "__Secure-" : ""}authjs.session-token`;
 }

--- a/middleware.ts
+++ b/middleware.ts
@@ -4,8 +4,10 @@ import type { JWT } from "next-auth/jwt";
 import { getToken } from "next-auth/jwt";
 import { getAuthSecret } from "@/lib/auth-secret";
 
-// NextAuth v5 renamed the session cookie from "next-auth.session-token" to "authjs.session-token"
-const SESSION_COOKIE = "authjs.session-token";
+// NextAuth v5 renamed the session cookie from "next-auth.session-token" to "authjs.session-token".
+// In production (HTTPS), @auth/core prefixes cookies with "__Secure-".
+const useSecureCookies = (process.env.AUTH_URL ?? process.env.NEXTAUTH_URL ?? "").startsWith("https://");
+const SESSION_COOKIE = `${useSecureCookies ? "__Secure-" : ""}authjs.session-token`;
 
 function isShopperToken(token: Awaited<ReturnType<typeof getToken>>) {
   if (!token || typeof token === "string") return false;


### PR DESCRIPTION
## Summary
- Fixes redirect loop after owner login (`/owner-dashboard` → `/dashboard` → `/login` → repeat)
- Root cause: NextAuth v5 renamed the session cookie from `next-auth.session-token` to `authjs.session-token`. The middleware's `getToken()` call didn't specify `cookieName`, so it looked for the old v4 name and always returned null — treating every authenticated request as unauthenticated
- Fix: pass `cookieName: "authjs.session-token"` to `getToken()`

## Test plan
- [x] Owner login → lands on `/dashboard` without redirect loop
- [x] Shopper hitting `/dashboard` → redirects to `/shopper/account`
- [x] Unauthenticated user hitting `/dashboard` → redirects to `/login`

🤖 Generated with [Claude Code](https://claude.com/claude-code)