### PR TITLE
fix(validation): reject emails without a valid TLD

### DIFF
--- a/app/(public)/shopper/signup/ShopperSignupForm.tsx
+++ b/app/(public)/shopper/signup/ShopperSignupForm.tsx
@@ -7,8 +7,7 @@ import {
   isSafeRelativeAppPath,
   safeCallbackPath,
 } from "@/lib/safe-callback-path";
-
-const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+import { EMAIL_RE } from "@/lib/email/validate";
 
 interface SignupApiResponse {
   ok?: boolean;

--- a/app/(public)/shopper/signup/ShopperSignupForm.tsx
+++ b/app/(public)/shopper/signup/ShopperSignupForm.tsx
@@ -8,6 +8,8 @@ import {
   safeCallbackPath,
 } from "@/lib/safe-callback-path";
 
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
 interface SignupApiResponse {
   ok?: boolean;
   redirectUrl?: string;
@@ -33,6 +35,13 @@ export default function ShopperSignupForm() {
     e.preventDefault();
     setError(null);
     setFieldErrors({});
+
+    if (!EMAIL_RE.test(email.trim())) {
+      setFieldErrors({ email: "Enter a valid email address." });
+      setError("Please fix the errors below.");
+      return;
+    }
+
     setPending(true);
     try {
       const res = await fetch("/auth/shopper/signup", {

--- a/app/(public)/signup/SignupForm.tsx
+++ b/app/(public)/signup/SignupForm.tsx
@@ -8,6 +8,8 @@ import {
   safeCallbackPath,
 } from "@/lib/safe-callback-path";
 
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
 interface SignupApiResponse {
   ok?: boolean;
   redirectUrl?: string;
@@ -36,6 +38,13 @@ export default function SignupForm() {
     e.preventDefault();
     setError(null);
     setFieldErrors({});
+
+    if (!EMAIL_RE.test(email.trim())) {
+      setFieldErrors({ email: "Enter a valid email address." });
+      setError("Please fix the errors below.");
+      return;
+    }
+
     setPending(true);
     try {
       const res = await fetch("/auth/signup", {

--- a/app/(public)/signup/SignupForm.tsx
+++ b/app/(public)/signup/SignupForm.tsx
@@ -7,8 +7,7 @@ import {
   isSafeRelativeAppPath,
   safeCallbackPath,
 } from "@/lib/safe-callback-path";
-
-const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+import { EMAIL_RE } from "@/lib/email/validate";
 
 interface SignupApiResponse {
   ok?: boolean;

--- a/lib/email/validate.ts
+++ b/lib/email/validate.ts
@@ -1,0 +1,8 @@
+/**
+ * Shared email regex used by both client-side forms and server-side validators.
+ *
+ * Requires an alphabetic TLD (≥2 chars), which rejects addresses like
+ * user@fake (no TLD) and user@example.123 (numeric TLD).
+ */
+export const EMAIL_RE =
+  /^[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@(?=[^@]*\.[a-zA-Z]{2,}$)[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$/;

--- a/lib/validate-owner-signup.ts
+++ b/lib/validate-owner-signup.ts
@@ -1,4 +1,5 @@
 import { safeCallbackPath } from "@/lib/safe-callback-path";
+import { EMAIL_RE } from "@/lib/email/validate";
 
 export type OwnerSignupInput = {
   email: string;
@@ -12,8 +13,6 @@ export type SignupValidationResult =
   | { ok: true; data: OwnerSignupInput }
   | { ok: false; errors: Record<string, string> };
 
-const EMAIL_RE =
-  /^[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@(?=[^@]*\.[a-zA-Z]{2,}$)[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$/;
 
 export function validateSignupInput(
   body: unknown,

--- a/lib/validate-owner-signup.ts
+++ b/lib/validate-owner-signup.ts
@@ -13,7 +13,7 @@ export type SignupValidationResult =
   | { ok: false; errors: Record<string, string> };
 
 const EMAIL_RE =
-  /^[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$/;
+  /^[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@(?=[^@]*\.[a-zA-Z]{2,}$)[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$/;
 
 export function validateSignupInput(
   body: unknown,

--- a/lib/validate-shopper-signup.ts
+++ b/lib/validate-shopper-signup.ts
@@ -12,7 +12,7 @@ export type ShopperSignupValidationResult =
   | { ok: false; errors: Record<string, string> };
 
 const EMAIL_RE =
-  /^[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$/;
+  /^[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@(?=[^@]*\.[a-zA-Z]{2,}$)[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$/;
 
 export function validateShopperSignup(body: unknown): ShopperSignupValidationResult {
   if (!body || typeof body !== "object") {

--- a/lib/validate-shopper-signup.ts
+++ b/lib/validate-shopper-signup.ts
@@ -1,4 +1,5 @@
 import { safeCallbackPath } from "@/lib/safe-callback-path";
+import { EMAIL_RE } from "@/lib/email/validate";
 
 export type ShopperSignupInput = {
   email: string;
@@ -11,8 +12,6 @@ export type ShopperSignupValidationResult =
   | { ok: true; data: ShopperSignupInput }
   | { ok: false; errors: Record<string, string> };
 
-const EMAIL_RE =
-  /^[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@(?=[^@]*\.[a-zA-Z]{2,}$)[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$/;
 
 export function validateShopperSignup(body: unknown): ShopperSignupValidationResult {
   if (!body || typeof body !== "object") {

--- a/tests/email-validate.test.ts
+++ b/tests/email-validate.test.ts
@@ -1,0 +1,97 @@
+import { EMAIL_RE } from "@/lib/email/validate";
+import { validateSignupInput } from "@/lib/validate-owner-signup";
+import { validateShopperSignup } from "@/lib/validate-shopper-signup";
+
+// ---------------------------------------------------------------------------
+// EMAIL_RE — shared regex
+// ---------------------------------------------------------------------------
+
+describe("EMAIL_RE", () => {
+  it("accepts a standard address", () => {
+    expect(EMAIL_RE.test("user@example.com")).toBe(true);
+  });
+
+  it("accepts a subdomain address", () => {
+    expect(EMAIL_RE.test("user@mail.example.com")).toBe(true);
+  });
+
+  it("accepts a two-part TLD (co.uk)", () => {
+    expect(EMAIL_RE.test("user@example.co.uk")).toBe(true);
+  });
+
+  it("rejects an address with no TLD (user@fake)", () => {
+    expect(EMAIL_RE.test("user@fake")).toBe(false);
+  });
+
+  it("rejects a numeric TLD (user@fake.123)", () => {
+    expect(EMAIL_RE.test("user@fake.123")).toBe(false);
+  });
+
+  it("rejects a missing domain", () => {
+    expect(EMAIL_RE.test("user@")).toBe(false);
+  });
+
+  it("rejects a missing local part", () => {
+    expect(EMAIL_RE.test("@example.com")).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// validateSignupInput (owner) — parity with EMAIL_RE
+// ---------------------------------------------------------------------------
+
+const validOwnerBase = {
+  name: "Alice",
+  email: "alice@example.com",
+  password: "Pass1234",
+  confirmPassword: "Pass1234",
+};
+
+describe("validateSignupInput (owner) email parity", () => {
+  it("rejects user@fake (no TLD)", () => {
+    const result = validateSignupInput({ ...validOwnerBase, email: "user@fake" });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.errors.email).toMatch(/valid email/i);
+  });
+
+  it("rejects user@fake.123 (numeric TLD)", () => {
+    const result = validateSignupInput({ ...validOwnerBase, email: "user@fake.123" });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.errors.email).toMatch(/valid email/i);
+  });
+
+  it("accepts user@example.co.uk", () => {
+    const result = validateSignupInput({ ...validOwnerBase, email: "user@example.co.uk" });
+    expect(result.ok).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// validateShopperSignup — parity with EMAIL_RE
+// ---------------------------------------------------------------------------
+
+const validShopperBase = {
+  name: "Bob",
+  email: "bob@example.com",
+  password: "Pass1234",
+  confirmPassword: "Pass1234",
+};
+
+describe("validateShopperSignup email parity", () => {
+  it("rejects user@fake (no TLD)", () => {
+    const result = validateShopperSignup({ ...validShopperBase, email: "user@fake" });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.errors.email).toMatch(/valid email/i);
+  });
+
+  it("rejects user@fake.123 (numeric TLD)", () => {
+    const result = validateShopperSignup({ ...validShopperBase, email: "user@fake.123" });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.errors.email).toMatch(/valid email/i);
+  });
+
+  it("accepts user@example.co.uk", () => {
+    const result = validateShopperSignup({ ...validShopperBase, email: "user@example.co.uk" });
+    expect(result.ok).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

- Adds a lookahead assertion `(?=[^@]*\.[a-zA-Z]{2,}$)` to `EMAIL_RE` in both `validate-owner-signup.ts` and `validate-shopper-signup.ts`
- Domains with no dot (e.g. `user@fake`) or a numeric-only TLD (e.g. `user@fake.123`) are now rejected at the server
- Valid addresses like `user@example.com` and `user@example.co.uk` continue to pass

Closes #148, closes #146.

## Test plan

- [ ] Try signing up as a store owner with `user@fake` — should see "Enter a valid email address." error
- [ ] Try signing up as a shopper with `user@notreal` — same error
- [ ] Confirm valid emails (e.g. `user@example.com`) still complete signup successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)