### PR TITLE
fix: allow business owners to access shopper sign-in page

### DIFF
--- a/app/(public)/shopper/login/page.tsx
+++ b/app/(public)/shopper/login/page.tsx
@@ -6,8 +6,10 @@ import ShopperLoginForm from "./ShopperLoginForm";
 
 export default async function ShopperLoginPage() {
   const session = await auth();
-  if (session?.user) {
-    redirect(session.role === "shopper" ? "/" : "/owner-dashboard");
+  // Only redirect already-authenticated shoppers — business owners should be
+  // allowed to reach this page so they can sign in with a separate shopper account.
+  if (session?.user && session.role === "shopper") {
+    redirect("/");
   }
 
   return (


### PR DESCRIPTION
## Summary
- Fixed redirect logic so business owners can navigate to /shopper/login
- Previously, any authenticated user (including business owners) was redirected away from the shopper login page
- Now only authenticated shoppers are redirected; business owners see the shopper sign-in form normally
- Fixes #162

## Test plan
- [ ] Log in as a business owner
- [ ] Click 'sign in as shopper' link
- [ ] Should be taken to the shopper login page, not redirected to the business dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)