### PR TITLE
fix: improve text contrast for view store button on map

### DIFF
--- a/components/StoreMap.tsx
+++ b/components/StoreMap.tsx
@@ -64,7 +64,8 @@ export default function StoreMap({
               )}
               <Link
                 href={`/stores/${store.id}`}
-                className="inline-block mt-2 text-[12px] font-medium text-white bg-green-600 px-3 py-1 rounded-md hover:bg-green-800 transition-colors"
+                className="inline-block mt-2 text-[12px] font-semibold text-white bg-green-700 px-3 py-1 rounded-md hover:bg-green-800 transition-colors"
+                style={{ color: "#ffffff" }}
               >
                 View store →
               </Link>


### PR DESCRIPTION
## Summary
- Fixed poor color contrast on 'View store' button in map popups (was dark blue on dark green)
- Added inline color override to defeat Leaflet's default link CSS, ensuring white text is always visible
- Fixes #167

## Test plan
- [ ] Navigate to the map view
- [ ] Click a store marker to open popup
- [ ] 'View store' text should be clearly readable (white on dark green)

🤖 Generated with [Claude Code](https://claude.com/claude-code)