### PR TITLE
fix: show environment-appropriate copy on forgot password page

### DIFF
--- a/app/(public)/login/forgot/page.tsx
+++ b/app/(public)/login/forgot/page.tsx
@@ -45,8 +45,10 @@ export default function ForgotPasswordPage() {
         <div className="mb-1.5 font-display text-2xl font-semibold text-green-600">Reset password</div>
         <p className="mb-6 text-[14px] text-gray-400">
           Enter the email you use for your store owner account. If outbound email is configured for this
-          app, you&apos;ll receive a reset link shortly. In local development without email, check the server
-          terminal for the URL.
+          app, you&apos;ll receive a reset link shortly.{" "}
+          {process.env.NODE_ENV === "development"
+            ? "In local development without email, check the server terminal for the URL."
+            : "If you don’t receive an email within a few minutes, please contact support."}
         </p>
 
         <form onSubmit={onSubmit} className="space-y-4">

--- a/app/(public)/login/forgot/page.tsx
+++ b/app/(public)/login/forgot/page.tsx
@@ -44,11 +44,9 @@ export default function ForgotPasswordPage() {
       <div className="w-full max-w-[420px] rounded-3xl border border-gray-200 bg-white p-10 shadow-md">
         <div className="mb-1.5 font-display text-2xl font-semibold text-green-600">Reset password</div>
         <p className="mb-6 text-[14px] text-gray-400">
-          Enter the email you use for your store owner account. If outbound email is configured for this
-          app, you&apos;ll receive a reset link shortly.{" "}
           {process.env.NODE_ENV === "development"
-            ? "In local development without email, check the server terminal for the URL."
-            : "If you don’t receive an email within a few minutes, please contact support."}
+            ? "Enter the email you use for your store owner account. If outbound email is configured for this app, you’ll receive a reset link shortly. In local development without email, check the server terminal for the URL."
+            : "If your email address is registered, you will receive a password reset link shortly. Please check your inbox and spam folder."}
         </p>
 
         <form onSubmit={onSubmit} className="space-y-4">


### PR DESCRIPTION
## Summary
- Forgot password page now shows user-friendly 'check your inbox' message in production
- Dev mode still shows the 'check server terminal' developer instructions
- Fixes #173

## Test plan
- [ ] In development: see terminal-check instructions
- [ ] In production build: see user-friendly 'check your inbox' message only

🤖 Generated with [Claude Code](https://claude.com/claude-code)