### PR TITLE
fix: correct store card button links and remove duplicates

### DIFF
--- a/components/StoreCard.tsx
+++ b/components/StoreCard.tsx
@@ -39,12 +39,10 @@ interface StoreCardProps {
 export default function StoreCard({ store, neighborhood }: StoreCardProps) {
   const coverSrc = getStoreCoverImageUrl(store.id, store.categories);
   const emoji = heroEmoji(store.categories);
+  const mapsUrl = `https://www.google.com/maps/dir/?api=1&destination=${encodeURIComponent(store.address)}`;
 
   return (
-    <Link
-      href={`/stores/${store.id}`}
-      className="group relative flex flex-col overflow-hidden rounded-2xl border border-stone-200/80 bg-white shadow-[0_1px_3px_rgba(15,23,42,0.06),0_8px_24px_-4px_rgba(15,23,42,0.08)] transition duration-300 hover:-translate-y-1 hover:border-emerald-300/60 hover:shadow-[0_12px_40px_-8px_rgba(15,23,42,0.15)] active:translate-y-0 active:scale-[0.99]"
-    >
+    <div className="group relative flex flex-col overflow-hidden rounded-2xl border border-stone-200/80 bg-white shadow-[0_1px_3px_rgba(15,23,42,0.06),0_8px_24px_-4px_rgba(15,23,42,0.08)] transition duration-300 hover:-translate-y-1 hover:border-emerald-300/60 hover:shadow-[0_12px_40px_-8px_rgba(15,23,42,0.15)] active:translate-y-0 active:scale-[0.99]">
       <div className="relative h-[152px] w-full overflow-hidden bg-stone-200">
         <Image
           src={coverSrc}
@@ -85,7 +83,25 @@ export default function StoreCard({ store, neighborhood }: StoreCardProps) {
             ))}
           </div>
         )}
+        <div className="mt-4 flex gap-2">
+          <a
+            href={mapsUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="flex-1 rounded-lg border border-stone-200 bg-stone-50 px-3 py-2 text-center text-[13px] font-semibold text-stone-700 transition hover:bg-stone-100"
+            onClick={(e) => e.stopPropagation()}
+          >
+            Get Directions
+          </a>
+          <Link
+            href={`/stores/${store.id}`}
+            className="flex-1 rounded-lg bg-emerald-600 px-3 py-2 text-center text-[13px] font-semibold text-white transition hover:bg-emerald-700"
+            onClick={(e) => e.stopPropagation()}
+          >
+            Visit Store
+          </Link>
+        </div>
       </div>
-    </Link>
+    </div>
   );
 }

--- a/tests/StoreCard.test.tsx
+++ b/tests/StoreCard.test.tsx
@@ -41,7 +41,7 @@ describe("StoreCard", () => {
 
   it("links to the store profile", () => {
     render(<StoreCard store={base} neighborhood="Shadyside" />);
-    const link = screen.getByRole("link");
+    const link = screen.getByRole("link", { name: /Visit Store/i });
     expect(link).toHaveAttribute("href", "/stores/s1");
   });
 


### PR DESCRIPTION
## Summary
- 'Get Directions' button now links to Google Maps with the store's address
- 'Visit Store' button links to the store detail page within the app (/stores/[id])
- Removed the duplicate outer-link wrapper that caused both actions to go to the same place
- Fixes #155 and #161

## Test plan
- [ ] Click 'Get Directions' — opens Google Maps with the store address
- [ ] Click 'Visit Store' — navigates to the store detail page
- [ ] No duplicate buttons present

🤖 Generated with [Claude Code](https://claude.com/claude-code)