### PR TITLE
fix: correct pluralization typo in browse page store count

### DIFF
--- a/components/marketplace/MarketplaceBrowseClient.tsx
+++ b/components/marketplace/MarketplaceBrowseClient.tsx
@@ -88,8 +88,7 @@ export default function MarketplaceBrowseClient({
       >
         <p className="text-sm text-stone-500">
           Showing{" "}
-          <span className="font-semibold text-stone-800">{visible.length}</span> listing
-          {visible.length !== 1 ? "s" : ""}
+          <span className="font-semibold text-stone-800">{visible.length}</span> listing{visible.length !== 1 ? "s" : ""}
         </p>
         <div className="flex flex-wrap gap-2">
           {FILTERS.map((chip) => (


### PR DESCRIPTION
## Summary
- Fixed 'Showing 6 listing s' — now correctly shows 'Showing 6 listings' or 'Showing 1 listing'
- Removed the stray space before the conditional 's'
- Fixes #168

## Test plan
- [ ] Navigate to /browse
- [ ] Count shows 'Showing N listings' with no extra space
- [ ] With 1 result: shows 'Showing 1 listing'

🤖 Generated with [Claude Code](https://claude.com/claude-code)