### PR TITLE
fix: add missing space in footer copyright string

### DIFF
--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -2,7 +2,7 @@ export default function Footer() {
   return (
     <footer className="border-t border-gray-200 bg-white dark:bg-gray-950 dark:border-gray-800 mt-auto">
       <div className="mx-auto max-w-7xl px-4 py-6 sm:px-6 lg:px-8 text-center text-sm text-gray-500">
-        &copy; {new Date().getFullYear()} GrocerEase &middot; Local discovery, no
+        &copy; {new Date().getFullYear()}{" "}GrocerEase &middot; Local discovery, no
         checkout
       </div>
     </footer>


### PR DESCRIPTION
## Summary
- Fixed footer rendering '© 2026GrocerEase' to correctly show '© 2026 GrocerEase'
- Affects all pages that use the Footer component
- Fixes #169

## Test plan
- [ ] Visit /my-alerts — footer shows '© 2026 GrocerEase · Local discovery, no checkout'
- [ ] Visit /login/forgot — same footer fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)