### PR TITLE
fix: look up store from DB so post-login profile completions unblock deals

### DIFF
--- a/app/(dashboard)/dashboard/deals/page.tsx
+++ b/app/(dashboard)/dashboard/deals/page.tsx
@@ -1,25 +1,94 @@
+import Link from "next/link";
 import { auth } from "@/auth";
 import OwnerDealExpiryAlerts from "@/components/OwnerDealExpiryAlerts";
 import { prisma } from "@/lib/prisma";
 import { redirect } from "next/navigation";
 import ManageDealsClient from "./ManageDealsClient";
 
+function getMissingProfileFields(store: {
+  name: string;
+  address: string;
+  hours: unknown;
+  categories: string[];
+}): string[] {
+  const missing: string[] = [];
+  if (!store.name?.trim()) missing.push("store name");
+  if (!store.address?.trim()) missing.push("store address");
+  const hours = store.hours as { open?: unknown; close?: unknown } | null;
+  if (!hours || !hours.open || !hours.close) missing.push("store hours");
+  if (!Array.isArray(store.categories) || store.categories.length === 0)
+    missing.push("specialty category");
+  return missing;
+}
+
 export default async function ManageDealsPage() {
   const session = await auth();
   if (!session?.user?.id) redirect("/login");
 
-  if (!session.storeId) {
+  // Always look up the store from the database by owner ID so that owners who
+  // completed their profile after logging in are not incorrectly blocked by a
+  // stale storeId in their session JWT (fixes #163).
+  const store = await prisma.store.findUnique({
+    where: { ownerId: session.user.id },
+    select: {
+      id: true,
+      name: true,
+      address: true,
+      hours: true,
+      categories: true,
+      isPublished: true,
+    },
+  });
+
+  const pageHeader = (
+    <div className="mb-7">
+      <p className="text-[11px] font-semibold uppercase tracking-wider text-gray-400 mb-2">
+        Owner portal
+      </p>
+      <h1 className="font-display text-[28px] font-medium text-gray-800 tracking-tight">
+        Deals
+      </h1>
+    </div>
+  );
+
+  if (!store) {
     return (
       <div className="max-w-[700px]">
-        <p className="text-[11px] font-semibold uppercase tracking-wider text-gray-400 mb-2">
-          Owner portal
-        </p>
-        <h1 className="font-display text-[28px] font-medium text-gray-800 tracking-tight">
-          Deals
-        </h1>
-        <p className="text-[15px] text-gray-600 mt-4">
-          Complete your store profile first, then you can post deals.
-        </p>
+        {pageHeader}
+        <div className="rounded-lg border border-amber-200 bg-amber-50 px-4 py-3 text-[14px] text-amber-900">
+          <p className="font-semibold mb-1">Store profile required</p>
+          <p>
+            You need to create your store profile before you can post deals.{" "}
+            <Link
+              href="/dashboard/profile"
+              className="font-medium text-amber-800 underline hover:text-amber-950"
+            >
+              Set up your store profile →
+            </Link>
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  const missingFields = getMissingProfileFields(store);
+  if (missingFields.length > 0) {
+    return (
+      <div className="max-w-[700px]">
+        {pageHeader}
+        <div className="rounded-lg border border-amber-200 bg-amber-50 px-4 py-3 text-[14px] text-amber-900">
+          <p className="font-semibold mb-1">Your store profile must be complete before posting deals.</p>
+          <p className="mb-2">
+            Missing:{" "}
+            <span className="font-medium">{missingFields.join(", ")}</span>.
+          </p>
+          <Link
+            href="/dashboard/profile"
+            className="font-medium text-amber-800 underline hover:text-amber-950"
+          >
+            Complete your store profile →
+          </Link>
+        </div>
       </div>
     );
   }
@@ -51,7 +120,7 @@ export default async function ManageDealsPage() {
       <OwnerDealExpiryAlerts
         initial={alerts.map((a) => ({ id: a.id, message: a.message }))}
       />
-      <ManageDealsClient storeId={session.storeId} />
+      <ManageDealsClient storeId={store.id} />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Fixed bug where owners who complete their store profile without re-logging in remain blocked from posting deals
- Root cause: deals page used stale `session.storeId` (null until next JWT refresh) instead of querying DB
- Now queries store directly by `ownerId`, so profile completion is reflected immediately
- Added specific missing-field list in the error message (e.g., 'Missing: store address, specialty category')
- Fixes #163 and #160

## Test plan
- [ ] Create owner account, complete store profile, go to Deals page without logging out — should now show the deals form
- [ ] Incomplete profile: error message clearly lists which fields are missing
- [ ] Full deal posting flow works end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)