### PR TITLE
feat: implement password reset flow for store owners

### DIFF
--- a/app/(public)/login/reset/page.tsx
+++ b/app/(public)/login/reset/page.tsx
@@ -48,7 +48,9 @@ function ResetPasswordForm() {
       <div className="w-full max-w-[420px] rounded-3xl border border-gray-200 bg-white p-10 shadow-md">
         <div className="mb-1.5 font-display text-2xl font-semibold text-green-600">Set new password</div>
         <p className="mb-6 text-[14px] text-gray-400">
-          Paste the reset token from your email (or from the server log in development).
+          {tokenFromQuery
+            ? "Enter and confirm your new password below."
+            : "Paste the reset token from your email, then choose a new password."}
         </p>
 
         <form onSubmit={onSubmit} className="space-y-4">
@@ -61,20 +63,22 @@ function ResetPasswordForm() {
             </div>
           )}
 
-          <div>
-            <label htmlFor="reset-token" className="mb-1.5 block text-[13px] font-medium text-gray-600">
-              Reset token
-            </label>
-            <input
-              id="reset-token"
-              type="text"
-              autoComplete="off"
-              required
-              value={token}
-              onChange={(e) => setToken(e.target.value)}
-              className="w-full rounded-md border-[1.5px] border-gray-200 bg-white px-3.5 py-2.5 text-[15px] text-gray-800 outline-none transition-colors focus:border-green-400"
-            />
-          </div>
+          {!tokenFromQuery && (
+            <div>
+              <label htmlFor="reset-token" className="mb-1.5 block text-[13px] font-medium text-gray-600">
+                Reset token
+              </label>
+              <input
+                id="reset-token"
+                type="text"
+                autoComplete="off"
+                required
+                value={token}
+                onChange={(e) => setToken(e.target.value)}
+                className="w-full rounded-md border-[1.5px] border-gray-200 bg-white px-3.5 py-2.5 text-[15px] text-gray-800 outline-none transition-colors focus:border-green-400"
+              />
+            </div>
+          )}
 
           <div>
             <label htmlFor="reset-password" className="mb-1.5 block text-[13px] font-medium text-gray-600">


### PR DESCRIPTION
## Summary
Complete password reset flow for store owners:

- **Forgot password page** (`/login/forgot`): Owner enters email, receives a reset link
- **Reset password page** (`/login/reset?token=...`): Token auto-filled from URL, token field hidden for cleaner UX when following a link; manual token entry still works
- **`POST /auth/forgot-password`**: Generates a secure token (crypto.randomBytes), stores SHA-256 hash, expires in 1 hour; sends via Resend/SendGrid if configured; dev-only console log as fallback; no email enumeration
- **`POST /auth/reset-password`**: Validates token hash, enforces single-use (DELETE after success), bcrypt (12 rounds) for new password
- **Rate limiting** on both endpoints

Closes #25

## Test plan
- [ ] Request reset for a registered email — dev: reset URL in console; prod with email provider: email sent
- [ ] Click the reset link — token field is hidden, just enter new password
- [ ] Submit new password — login succeeds with new credentials
- [ ] Try the reset link again — shows invalid/expired error
- [ ] Request reset for an unregistered email — same generic success message (no enumeration)
- [ ] Token older than 1 hour — invalid/expired error

🤖 Generated with [Claude Code](https://claude.com/claude-code)