### PR TITLE
fix: remove Reset demo data button from vendor dashboard

### DIFF
--- a/components/marketplace/VendorDashboardClient.tsx
+++ b/components/marketplace/VendorDashboardClient.tsx
@@ -32,8 +32,6 @@ export default function VendorDashboardClient() {
   const addListing = useMarketplaceStore((s) => s.addListing);
   const updateListing = useMarketplaceStore((s) => s.updateListing);
   const deleteListing = useMarketplaceStore((s) => s.deleteListing);
-  const resetToSeed = useMarketplaceStore((s) => s.resetToSeed);
-
   const [editingId, setEditingId] = useState<string | null>(null);
   const [form, setForm] = useState<MarketplaceListingInput>(emptyForm);
   const [message, setMessage] = useState<string | null>(null);
@@ -240,16 +238,6 @@ export default function VendorDashboardClient() {
             <h2 className="font-display text-xl font-semibold text-stone-900">
               Active inventory
             </h2>
-            <button
-              type="button"
-              onClick={() => {
-                resetToSeed();
-                setMessage("Reset to demo seed data.");
-              }}
-              className="self-start rounded-lg border border-stone-200 px-3 py-1.5 text-xs font-medium text-stone-600 hover:bg-stone-50"
-            >
-              Reset demo data
-            </button>
           </div>
           <p className="mt-1 text-sm text-stone-500">
             {sorted.length} listing{sorted.length !== 1 ? "s" : ""} · same data as{" "}


### PR DESCRIPTION
## Summary

Removes the "Reset demo data" button from the Active inventory section of the vendor dashboard (`/vendor`). The button called `resetToSeed()` to restore the in-memory marketplace store to its initial seed state — a development convenience that has no place in production or a public demo.

- Removed the button element and its `onClick` handler
- Removed the now-unused `resetToSeed` selector from the component

## Test plan

- [ ] Visit `/vendor` as a logged-in owner — confirm no "Reset demo data" button appears
- [ ] Confirm adding, editing, and deleting inventory still works normally
- [ ] `npm run test:jest` — 254 tests pass ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)