### PR TITLE
fix: make entire store card clickable to navigate to store page

### DIFF
--- a/components/StoreCard.tsx
+++ b/components/StoreCard.tsx
@@ -29,6 +29,13 @@ export default function StoreCard({ store, neighborhood }: StoreCardProps) {
 
   return (
     <div className="group relative flex flex-col overflow-hidden rounded-2xl border border-stone-200/80 bg-white shadow-[0_1px_3px_rgba(15,23,42,0.06),0_8px_24px_-4px_rgba(15,23,42,0.08)] transition duration-300 hover:-translate-y-1 hover:border-emerald-300/60 hover:shadow-[0_12px_40px_-8px_rgba(15,23,42,0.15)] active:translate-y-0 active:scale-[0.99]">
+      {/* Stretched link — makes the whole card navigate to the store page.
+          Action buttons sit above it via relative z-10. */}
+      <Link
+        href={`/stores/${store.id}`}
+        className="absolute inset-0 rounded-2xl focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500 focus-visible:ring-offset-2"
+        aria-label={`View ${store.name}`}
+      />
       <div className="relative h-[152px] w-full overflow-hidden bg-stone-200">
         <Image
           src={coverSrc}
@@ -69,20 +76,18 @@ export default function StoreCard({ store, neighborhood }: StoreCardProps) {
             ))}
           </div>
         )}
-        <div className="mt-4 flex gap-2">
+        <div className="relative z-10 mt-4 flex gap-2">
           <a
             href={mapsUrl}
             target="_blank"
             rel="noopener noreferrer"
             className="flex-1 rounded-lg border border-stone-200 bg-stone-50 px-3 py-2 text-center text-[13px] font-semibold text-stone-700 transition hover:bg-stone-100"
-            onClick={(e) => e.stopPropagation()}
           >
             Get Directions
           </a>
           <Link
             href={`/stores/${store.id}`}
             className="flex-1 rounded-lg bg-emerald-600 px-3 py-2 text-center text-[13px] font-semibold text-white transition hover:bg-emerald-700"
-            onClick={(e) => e.stopPropagation()}
           >
             Visit Store
           </Link>


### PR DESCRIPTION
## Summary

- Clicking anywhere on a store card (image, name, address, tags) now navigates to the store profile page — previously only the "Visit Store" button worked.
- Uses a **stretched link** pattern: an absolutely-positioned `<Link>` as the first child of the card covers the full card area. The "Get Directions" and "Visit Store" buttons live in a `relative z-10` wrapper so they sit above the stretched link and intercept their own clicks normally.
- The stretched link carries `aria-label="View <store name>"` so screen readers announce the destination.
- No nested `<a>` elements — valid HTML. Keyboard-navigable (tab focuses the card link, Enter navigates). Removed the now-redundant `e.stopPropagation()` calls from the action buttons.

## Test plan

- [ ] On the home / discover page, click the cover photo of a store card → navigates to store profile
- [ ] Click the store name → navigates to store profile
- [ ] Click "Get Directions" → opens Google Maps (does **not** navigate to store profile)
- [ ] Click "Visit Store" → navigates to store profile
- [ ] Tab to a card, press Enter → navigates to store profile
- [ ] Right-click the card body → "Open link in new tab" is available
- [ ] `npm run test:jest` — 254 tests pass ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)