### PR TITLE
fix: Visit store on browse feed links to store detail page

### DIFF
--- a/components/marketplace/MarketplaceBrowseClient.tsx
+++ b/components/marketplace/MarketplaceBrowseClient.tsx
@@ -193,14 +193,23 @@ export default function MarketplaceBrowseClient({
                   >
                     Get directions
                   </a>
-                  <a
-                    href={mapsSearchUrl(`${item.shopName} ${item.shopAddress}`)}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="inline-flex flex-1 items-center justify-center rounded-xl border border-stone-300 bg-stone-50 px-4 py-3 text-center text-sm font-semibold text-stone-800 transition hover:bg-white"
-                  >
-                    Visit store
-                  </a>
+                  {item.storeId ? (
+                    <Link
+                      href={`/stores/${item.storeId}`}
+                      className="inline-flex flex-1 items-center justify-center rounded-xl border border-stone-300 bg-stone-50 px-4 py-3 text-center text-sm font-semibold text-stone-800 transition hover:bg-white"
+                    >
+                      Visit store
+                    </Link>
+                  ) : (
+                    <a
+                      href={mapsSearchUrl(`${item.shopName} ${item.shopAddress}`)}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="inline-flex flex-1 items-center justify-center rounded-xl border border-stone-300 bg-stone-50 px-4 py-3 text-center text-sm font-semibold text-stone-800 transition hover:bg-white"
+                    >
+                      Visit store
+                    </a>
+                  )}
                 </div>
               </div>
             </li>


### PR DESCRIPTION
## Summary

On the `/browse` (local feed) page, both "Get Directions" and "Visit Store" buttons were pointing to Google Maps. "Visit Store" now navigates to the store's detail page (`/stores/[storeId]`) instead.

- When `storeId` is present (all 35 seed listings, and any listing created through the vendor dashboard): uses a Next.js `Link` to `/stores/[storeId]`
- When `storeId` is absent (legacy listings predating the field): falls back to the previous Maps search behaviour

## Test plan
- [ ] Visit `/browse` → click "Visit Store" on any listing → lands on the store detail page, not Google Maps
- [ ] Click "Get Directions" → still opens Google Maps as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)