### PR TITLE
Add Local feed and Vendor links to owner portal header

### DIFF
--- a/components/OwnerHeader.tsx
+++ b/components/OwnerHeader.tsx
@@ -5,6 +5,8 @@ import { signOut, useSession } from "next-auth/react";
 
 const publicLinks = [
   { href: "/", label: "Discover Stores" },
+  { href: "/browse", label: "Local feed" },
+  { href: "/vendor", label: "Vendor" },
   { href: "/map", label: "Map" },
   { href: "/deals", label: "Deals" },
 ] as const;


### PR DESCRIPTION
## Summary
- Owner portal header (`OwnerHeader.tsx`) was showing only 3 nav links (Discover Stores, Map, Deals)
- Public site header shows 5 links; added the missing **Local feed** (`/browse`) and **Vendor** (`/vendor`) to match

## Test plan
- [ ] Sign in as a store owner → verify header shows: Discover Stores · Local feed · Vendor · Map · Deals
- [ ] Click Local feed → lands on `/browse`
- [ ] Click Vendor → lands on `/vendor`

🤖 Generated with [Claude Code](https://claude.com/claude-code)